### PR TITLE
test: add Zustand slice behavior coverage

### DIFF
--- a/src/stores/slices/zustandSlices.test.ts
+++ b/src/stores/slices/zustandSlices.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAppStore } from '../appStore';
+
+function makeWorkspace(id: string, name: string) {
+  const now = new Date().toISOString();
+  return {
+    id,
+    name,
+    template: 'blank' as const,
+    projectContext: '',
+    panes: [],
+    layout: { direction: 'horizontal' as const, sizes: [] },
+    promptPresets: [],
+    dirty: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    workspaces: [],
+    activeWorkspaceId: null,
+    focusedPaneId: null,
+    sendingPaneIds: new Set<string>(),
+  });
+});
+
+describe('workspacesSlice', () => {
+  it('creates workspaces with sequential default names and sets active workspace', () => {
+    const state = useAppStore.getState();
+
+    const firstId = state.createWorkspace('blank');
+    const secondId = state.createWorkspace('blank');
+
+    const nextState = useAppStore.getState();
+    expect(nextState.workspaces).toHaveLength(2);
+    expect(nextState.workspaces[0].name).toBe('Workspace 1');
+    expect(nextState.workspaces[1].name).toBe('Workspace 2');
+    expect(nextState.activeWorkspaceId).toBe(secondId);
+    expect(firstId).not.toBe(secondId);
+  });
+
+  it('deletes active workspace and falls back to first remaining workspace', () => {
+    useAppStore.setState({
+      workspaces: [makeWorkspace('ws-1', 'Workspace 1'), makeWorkspace('ws-2', 'Workspace 2')],
+      activeWorkspaceId: 'ws-2',
+    });
+
+    useAppStore.getState().deleteWorkspace('ws-2');
+
+    const nextState = useAppStore.getState();
+    expect(nextState.workspaces).toHaveLength(1);
+    expect(nextState.workspaces[0].id).toBe('ws-1');
+    expect(nextState.activeWorkspaceId).toBe('ws-1');
+  });
+});
+
+describe('panesSlice', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [makeWorkspace('ws-1', 'Workspace 1')],
+      activeWorkspaceId: 'ws-1',
+    });
+  });
+
+  it('creates a pane in workspace and marks it dirty', () => {
+    const paneId = useAppStore.getState().createPane('ws-1', { title: 'Pane 1' });
+
+    const nextState = useAppStore.getState();
+    const workspace = nextState.workspaces[0];
+
+    expect(paneId).toBeTypeOf('string');
+    expect(workspace.panes).toHaveLength(1);
+    expect(workspace.panes[0].title).toBe('Pane 1');
+    expect(workspace.dirty).toBe(true);
+  });
+
+  it('updates pane title and keeps change in store', () => {
+    const paneId = useAppStore.getState().createPane('ws-1', { title: 'Pane 1' });
+
+    useAppStore.getState().updatePane('ws-1', paneId, { title: 'Renamed Pane' });
+
+    const pane = useAppStore.getState().workspaces[0].panes[0];
+    expect(pane.title).toBe('Renamed Pane');
+  });
+
+  it('deletes focused pane and clears focus', () => {
+    const paneId = useAppStore.getState().createPane('ws-1', { title: 'Pane 1' });
+    useAppStore.setState({ focusedPaneId: paneId });
+
+    useAppStore.getState().deletePane('ws-1', paneId);
+
+    const nextState = useAppStore.getState();
+    expect(nextState.workspaces[0].panes).toHaveLength(0);
+    expect(nextState.focusedPaneId).toBeNull();
+  });
+
+  it('duplicates pane with copy suffix and empty messages', () => {
+    const paneId = useAppStore.getState().createPane('ws-1', { title: 'Pane 1' });
+    useAppStore.getState().addMessage('ws-1', paneId, {
+      id: 'm-1',
+      role: 'user',
+      content: 'hello',
+      timestamp: new Date().toISOString(),
+    });
+
+    const duplicateId = useAppStore.getState().duplicatePane('ws-1', paneId);
+
+    const panes = useAppStore.getState().workspaces[0].panes;
+    const duplicated = panes.find((p) => p.id === duplicateId);
+
+    expect(panes).toHaveLength(2);
+    expect(duplicated).toBeDefined();
+    expect(duplicated?.title).toBe('Pane 1 (Copy)');
+    expect(duplicated?.messages).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add store tests for workspacesSlice and panesSlice actions
- cover create/delete workspace behavior
- cover create/update/delete/duplicate pane behavior

## Related Issue
- Closes #10
- note issue: https://github.com/t-tonton/note/issues/10

## Verification
- npm run test
- npm run lint