### PR TITLE
 feat: add snippets picker MVP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,43 @@
+import { useEffect } from 'react';
 import { AppLayout } from './components/layout';
+import { SnippetPicker } from './features/snippets';
 import { WorkspaceContainer } from './features/workspaces';
 import { useInitialize, useKeyboardShortcuts } from './hooks';
+import { useAppStore } from './stores';
 
 function App() {
   useInitialize();
   useKeyboardShortcuts();
 
+  const openSnippetPicker = useAppStore((state) => state.openSnippetPicker);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+
+    const bind = async () => {
+      try {
+        const eventModule = await import('@tauri-apps/api/event');
+        unlisten = await eventModule.listen('menu-open-snippets', () => {
+          openSnippetPicker();
+        });
+      } catch {
+        // Running in browser/dev context without Tauri event bridge.
+      }
+    };
+
+    void bind();
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, [openSnippetPicker]);
+
   return (
-    <AppLayout>
-      <WorkspaceContainer />
-    </AppLayout>
+    <>
+      <AppLayout>
+        <WorkspaceContainer />
+      </AppLayout>
+      <SnippetPicker />
+    </>
   );
 }
 

--- a/src/components/layout/IconSidebar.tsx
+++ b/src/components/layout/IconSidebar.tsx
@@ -4,6 +4,7 @@ import { useAppStore, useActiveWorkspace } from '../../stores';
 export function IconSidebar() {
   const activeWorkspaceId = useAppStore((state) => state.activeWorkspaceId);
   const createPane = useAppStore((state) => state.createPane);
+  const openSnippetPicker = useAppStore((state) => state.openSnippetPicker);
   const activeWorkspace = useActiveWorkspace();
   const [settingsActive, setSettingsActive] = useState(false);
 
@@ -29,7 +30,6 @@ export function IconSidebar() {
         borderRight: '1px solid var(--border-subtle)',
       }}
     >
-      {/* Files */}
       <SidebarButton
         icon={<FilesIcon />}
         label="Explorer"
@@ -37,7 +37,6 @@ export function IconSidebar() {
         disabled
       />
 
-      {/* Search */}
       <SidebarButton
         icon={<SearchIcon />}
         label="Search"
@@ -45,7 +44,6 @@ export function IconSidebar() {
         disabled
       />
 
-      {/* Git */}
       <SidebarButton
         icon={<GitIcon />}
         label="Source Control"
@@ -53,10 +51,8 @@ export function IconSidebar() {
         disabled
       />
 
-      {/* Divider */}
       <div style={{ height: '1px', width: '24px', backgroundColor: 'var(--border-subtle)', margin: '8px 0' }} />
 
-      {/* New pane */}
       <SidebarButton
         icon={<PlusIcon />}
         label="New Pane"
@@ -65,7 +61,13 @@ export function IconSidebar() {
         disabled={!activeWorkspaceId}
       />
 
-      {/* Terminal */}
+      <SidebarButton
+        icon={<SnippetsIcon />}
+        label="Snippets"
+        shortcut="⌘⇧P"
+        onClick={openSnippetPicker}
+      />
+
       <SidebarButton
         icon={<TerminalIcon />}
         label="Terminal"
@@ -75,7 +77,6 @@ export function IconSidebar() {
 
       <div style={{ flex: 1 }} />
 
-      {/* API */}
       <SidebarButton
         icon={<ApiIcon />}
         label="API Settings"
@@ -83,7 +84,6 @@ export function IconSidebar() {
         disabled
       />
 
-      {/* Settings */}
       <SidebarButton
         icon={<SettingsIcon />}
         label="Settings"
@@ -180,6 +180,17 @@ function TerminalIcon() {
       <rect x="2.5" y="3.5" width="13" height="11" rx="2" />
       <path d="M5.5 7l2 2-2 2" />
       <path d="M9.5 11h3" />
+    </svg>
+  );
+}
+
+function SnippetsIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="12" height="12" rx="2" />
+      <path d="M6 7h6" />
+      <path d="M6 10h6" />
+      <path d="M6 13h4" />
     </svg>
   );
 }

--- a/src/features/snippets/components/SnippetPicker.tsx
+++ b/src/features/snippets/components/SnippetPicker.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useAppStore } from '../../../stores';
+import type { Snippet } from '../../../types';
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fallback below
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+export function SnippetPicker() {
+  const isOpen = useAppStore((state) => state.isSnippetPickerOpen);
+  const close = useAppStore((state) => state.closeSnippetPicker);
+  const snippets = useAppStore((state) => state.snippets);
+  const addSnippet = useAppStore((state) => state.addSnippet);
+  const updateSnippet = useAppStore((state) => state.updateSnippet);
+  const deleteSnippet = useAppStore((state) => state.deleteSnippet);
+
+  const [search, setSearch] = useState('');
+  const [newTitle, setNewTitle] = useState('');
+  const [newCommand, setNewCommand] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState('');
+  const [editingCommand, setEditingCommand] = useState('');
+  const [feedback, setFeedback] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return snippets;
+    return snippets.filter((snippet) =>
+      snippet.title.toLowerCase().includes(q) ||
+      snippet.command.toLowerCase().includes(q)
+    );
+  }, [search, snippets]);
+
+  const copySnippet = async (snippet: Snippet | undefined) => {
+    if (!snippet) return;
+    const ok = await copyToClipboard(snippet.command);
+    setFeedback(ok ? `Copied: ${snippet.title}` : 'Copy failed');
+  };
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        void copySnippet(filtered[0]);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, close, filtered]);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timer = setTimeout(() => setFeedback(''), 1400);
+    return () => clearTimeout(timer);
+  }, [feedback]);
+
+  if (!isOpen) return null;
+
+  const onAdd = () => {
+    const id = addSnippet(newTitle, newCommand);
+    if (!id) return;
+    setNewTitle('');
+    setNewCommand('');
+    setFeedback('Added');
+  };
+
+  const startEdit = (snippet: Snippet) => {
+    setEditingId(snippet.id);
+    setEditingTitle(snippet.title);
+    setEditingCommand(snippet.command);
+  };
+
+  const saveEdit = () => {
+    if (!editingId) return;
+    updateSnippet(editingId, { title: editingTitle, command: editingCommand });
+    setEditingId(null);
+    setEditingTitle('');
+    setEditingCommand('');
+    setFeedback('Updated');
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(3, 6, 18, 0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 60,
+        backdropFilter: 'blur(2px)',
+      }}
+      onClick={close}
+    >
+      <div
+        style={{
+          width: 'min(820px, 92vw)',
+          maxHeight: '86vh',
+          overflow: 'auto',
+          borderRadius: '12px',
+          border: '1px solid var(--border-default)',
+          background: 'linear-gradient(180deg, #111a33 0%, #0c1328 100%)',
+          boxShadow: '0 20px 60px rgba(0,0,0,0.5)',
+          padding: '14px',
+          color: 'var(--text-primary)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '10px' }}>
+          <h2 style={{ margin: 0, fontSize: '16px', fontWeight: 600 }}>Snippets</h2>
+          <button onClick={close} style={ghostButtonStyle}>Close</button>
+        </div>
+
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search snippets..."
+          style={inputStyle}
+        />
+
+        <div style={{ display: 'grid', gap: '8px', marginTop: '10px', marginBottom: '12px' }}>
+          <input
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            placeholder="New snippet title"
+            style={inputStyle}
+          />
+          <textarea
+            value={newCommand}
+            onChange={(e) => setNewCommand(e.target.value)}
+            placeholder="Command"
+            style={{ ...inputStyle, minHeight: '72px', resize: 'vertical' }}
+          />
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ color: 'var(--text-muted)', fontSize: '12px' }}>Cmd/Ctrl+Enter copies top result</span>
+            <button onClick={onAdd} style={primaryButtonStyle}>Add Snippet</button>
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gap: '8px' }}>
+          {filtered.map((snippet) => {
+            const isEditing = editingId === snippet.id;
+
+            if (isEditing) {
+              return (
+                <div key={snippet.id} style={cardStyle}>
+                  <input
+                    value={editingTitle}
+                    onChange={(e) => setEditingTitle(e.target.value)}
+                    style={inputStyle}
+                  />
+                  <textarea
+                    value={editingCommand}
+                    onChange={(e) => setEditingCommand(e.target.value)}
+                    style={{ ...inputStyle, minHeight: '80px', marginTop: '8px', resize: 'vertical' }}
+                  />
+                  <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '8px' }}>
+                    <button onClick={() => setEditingId(null)} style={ghostButtonStyle}>Cancel</button>
+                    <button onClick={saveEdit} style={primaryButtonStyle}>Save</button>
+                  </div>
+                </div>
+              );
+            }
+
+            return (
+              <div key={snippet.id} style={cardStyle}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px' }}>
+                  <div style={{ minWidth: 0 }}>
+                    <div style={{ fontSize: '14px', fontWeight: 600 }}>{snippet.title}</div>
+                    <pre style={{ margin: '6px 0 0 0', whiteSpace: 'pre-wrap', color: 'var(--text-secondary)', fontSize: '12px' }}>{snippet.command}</pre>
+                  </div>
+                  <div style={{ display: 'flex', gap: '6px', flexShrink: 0, alignItems: 'flex-start' }}>
+                    <button onClick={() => void copySnippet(snippet)} style={primaryButtonStyle}>Copy</button>
+                    <button onClick={() => startEdit(snippet)} style={ghostButtonStyle}>Edit</button>
+                    <button onClick={() => deleteSnippet(snippet.id)} style={dangerButtonStyle}>Delete</button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {feedback ? (
+          <div style={{ marginTop: '10px', color: '#a7f3d0', fontSize: '12px' }}>{feedback}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+const inputStyle: CSSProperties = {
+  width: '100%',
+  borderRadius: '8px',
+  border: '1px solid var(--border-default)',
+  background: 'var(--bg-input)',
+  color: 'var(--text-primary)',
+  padding: '8px 10px',
+  fontSize: '13px',
+};
+
+const cardStyle: CSSProperties = {
+  borderRadius: '9px',
+  border: '1px solid var(--border-subtle)',
+  background: 'rgba(255,255,255,0.02)',
+  padding: '10px',
+};
+
+const primaryButtonStyle: CSSProperties = {
+  border: '1px solid rgba(74, 222, 128, 0.45)',
+  background: 'rgba(74, 222, 128, 0.16)',
+  color: '#dcfce7',
+  borderRadius: '7px',
+  padding: '6px 10px',
+  fontSize: '12px',
+  cursor: 'pointer',
+};
+
+const ghostButtonStyle: CSSProperties = {
+  border: '1px solid var(--border-default)',
+  background: 'transparent',
+  color: 'var(--text-secondary)',
+  borderRadius: '7px',
+  padding: '6px 10px',
+  fontSize: '12px',
+  cursor: 'pointer',
+};
+
+const dangerButtonStyle: CSSProperties = {
+  border: '1px solid rgba(248, 113, 113, 0.55)',
+  background: 'rgba(248, 113, 113, 0.12)',
+  color: '#fecaca',
+  borderRadius: '7px',
+  padding: '6px 10px',
+  fontSize: '12px',
+  cursor: 'pointer',
+};

--- a/src/features/snippets/index.ts
+++ b/src/features/snippets/index.ts
@@ -1,0 +1,1 @@
+export { SnippetPicker } from './components/SnippetPicker';

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -11,10 +11,18 @@ export function useKeyboardShortcuts() {
   const zoomIn = useAppStore((state) => state.zoomIn);
   const zoomOut = useAppStore((state) => state.zoomOut);
   const resetZoom = useAppStore((state) => state.resetZoom);
+  const openSnippetPicker = useAppStore((state) => state.openSnippetPicker);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const isMod = e.metaKey || e.ctrlKey;
+
+      // Cmd+Shift+P: Open snippet picker
+      if (isMod && e.shiftKey && e.key.toLowerCase() === 'p') {
+        e.preventDefault();
+        openSnippetPicker();
+        return;
+      }
 
       // Cmd+T: New workspace tab
       if (isMod && e.key === 't') {
@@ -43,10 +51,9 @@ export function useKeyboardShortcuts() {
         e.preventDefault();
         if (activeWorkspaceId) {
           const workspace = workspaces.find((w) => w.id === activeWorkspaceId);
-          const newPaneId = createPane(activeWorkspaceId, {
+          createPane(activeWorkspaceId, {
             title: `Pane ${(workspace?.panes.length ?? 0) + 1}`,
           });
-          console.log('[useKeyboardShortcuts] Created pane:', newPaneId, 'total:', (workspace?.panes.length ?? 0) + 1);
         }
         return;
       }
@@ -82,7 +89,7 @@ export function useKeyboardShortcuts() {
       // Cmd+1-9: Switch to tab by number
       if (isMod && e.key >= '1' && e.key <= '9') {
         e.preventDefault();
-        const index = parseInt(e.key) - 1;
+        const index = parseInt(e.key, 10) - 1;
         if (index < workspaces.length) {
           setActiveWorkspace(workspaces[index].id);
         }
@@ -107,7 +114,6 @@ export function useKeyboardShortcuts() {
       if (isMod && e.key === '0') {
         e.preventDefault();
         resetZoom();
-        return;
       }
     };
 
@@ -126,5 +132,16 @@ export function useKeyboardShortcuts() {
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [workspaces, activeWorkspaceId, setActiveWorkspace, createWorkspace, deleteWorkspace, createPane, zoomIn, zoomOut, resetZoom]);
+  }, [
+    workspaces,
+    activeWorkspaceId,
+    setActiveWorkspace,
+    createWorkspace,
+    deleteWorkspace,
+    createPane,
+    zoomIn,
+    zoomOut,
+    resetZoom,
+    openSnippetPicker,
+  ]);
 }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -4,8 +4,9 @@ import { createWorkspacesSlice, type WorkspacesSlice } from './slices/workspaces
 import { createPanesSlice, type PanesSlice } from './slices/panesSlice';
 import { createLayoutSlice, type LayoutSlice } from './slices/layoutSlice';
 import { createSettingsSlice, type SettingsSlice } from './slices/settingsSlice';
+import { createSnippetsSlice, type SnippetsSlice } from './slices/snippetsSlice';
 
-export type AppStore = WorkspacesSlice & PanesSlice & LayoutSlice & SettingsSlice;
+export type AppStore = WorkspacesSlice & PanesSlice & LayoutSlice & SettingsSlice & SnippetsSlice;
 
 export const useAppStore = create<AppStore>()(
   devtools(
@@ -14,8 +15,9 @@ export const useAppStore = create<AppStore>()(
       ...createPanesSlice(...args),
       ...createLayoutSlice(...args),
       ...createSettingsSlice(...args),
+      ...createSnippetsSlice(...args),
     }),
-    { name: 'AgentTabStore' }
+    { name: 'TabbedTerminalStore' }
   )
 );
 

--- a/src/stores/slices/layoutSlice.ts
+++ b/src/stores/slices/layoutSlice.ts
@@ -7,6 +7,7 @@ export interface LayoutSlice {
   isNewTabModalOpen: boolean;
   isNewPaneModalOpen: boolean;
   isPaneSwitcherOpen: boolean;
+  isSnippetPickerOpen: boolean;
   editingPaneId: string | null;
 
   // Actions
@@ -20,6 +21,8 @@ export interface LayoutSlice {
   closePaneSwitcher: () => void;
   openPaneEditor: (paneId: string) => void;
   closePaneEditor: () => void;
+  openSnippetPicker: () => void;
+  closeSnippetPicker: () => void;
 }
 
 export const createLayoutSlice: StateCreator<
@@ -32,6 +35,7 @@ export const createLayoutSlice: StateCreator<
   isNewTabModalOpen: false,
   isNewPaneModalOpen: false,
   isPaneSwitcherOpen: false,
+  isSnippetPickerOpen: false,
   editingPaneId: null,
 
   toggleSideDrawer: () => {
@@ -72,5 +76,13 @@ export const createLayoutSlice: StateCreator<
 
   closePaneEditor: () => {
     set({ editingPaneId: null });
+  },
+
+  openSnippetPicker: () => {
+    set({ isSnippetPickerOpen: true });
+  },
+
+  closeSnippetPicker: () => {
+    set({ isSnippetPickerOpen: false });
   },
 });

--- a/src/stores/slices/snippetsSlice.ts
+++ b/src/stores/slices/snippetsSlice.ts
@@ -1,0 +1,114 @@
+import type { StateCreator } from 'zustand';
+import type { Snippet } from '../../types';
+import { generateId } from '../../utils';
+import type { AppStore } from '../appStore';
+
+const STORAGE_KEY = 'tabbed-terminal-snippets-v1';
+
+function readSnippetsFromStorage(): Snippet[] {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .filter((item): item is Snippet => {
+        return typeof item?.id === 'string' &&
+          typeof item?.title === 'string' &&
+          typeof item?.command === 'string' &&
+          typeof item?.createdAt === 'string' &&
+          typeof item?.updatedAt === 'string';
+      })
+      .slice(0, 500);
+  } catch {
+    return [];
+  }
+}
+
+function writeSnippetsToStorage(snippets: Snippet[]) {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snippets));
+  } catch {
+    // Best-effort persistence.
+  }
+}
+
+export interface SnippetsSlice {
+  snippets: Snippet[];
+
+  addSnippet: (title: string, command: string) => string;
+  updateSnippet: (id: string, updates: { title?: string; command?: string }) => void;
+  deleteSnippet: (id: string) => void;
+}
+
+export const createSnippetsSlice: StateCreator<
+  AppStore,
+  [],
+  [],
+  SnippetsSlice
+> = (set) => ({
+  snippets: readSnippetsFromStorage(),
+
+  addSnippet: (title, command) => {
+    const trimmedTitle = title.trim();
+    const trimmedCommand = command.trim();
+    if (!trimmedTitle || !trimmedCommand) return '';
+
+    const now = new Date().toISOString();
+    const id = generateId();
+    const snippet: Snippet = {
+      id,
+      title: trimmedTitle,
+      command: trimmedCommand,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    set((state) => {
+      const next = [snippet, ...state.snippets];
+      writeSnippetsToStorage(next);
+      return { snippets: next };
+    });
+
+    return id;
+  },
+
+  updateSnippet: (id, updates) => {
+    set((state) => {
+      const next = state.snippets.map((snippet) => {
+        if (snippet.id !== id) return snippet;
+
+        const title = updates.title?.trim();
+        const command = updates.command?.trim();
+
+        return {
+          ...snippet,
+          title: title || snippet.title,
+          command: command || snippet.command,
+          updatedAt: new Date().toISOString(),
+        };
+      });
+
+      writeSnippetsToStorage(next);
+      return { snippets: next };
+    });
+  },
+
+  deleteSnippet: (id) => {
+    set((state) => {
+      const next = state.snippets.filter((snippet) => snippet.id !== id);
+      writeSnippetsToStorage(next);
+      return { snippets: next };
+    });
+  },
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './workspace';
 export * from './pane';
 export * from './message';
+export * from './snippet';

--- a/src/types/snippet.ts
+++ b/src/types/snippet.ts
@@ -1,0 +1,7 @@
+export interface Snippet {
+  id: string;
+  title: string;
+  command: string;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
 ## Summary
  - add snippets store slice with local persistence (add/edit/delete/search)
  - add snippets picker modal with copy-to-clipboard workflow
  - add 3 entry points: Cmd/Ctrl+Shift+P, sidebar Snippets icon, and Tools > Snippets menu
  - wire tauri menu event to frontend picker open action

  ## Notes
  - this PR intentionally uses modal UI for MVP safety
  - non-modal side panel improvement will be handled in a follow-up issue

  ## Verification
  - npm run lint
  - npm run test
  - npm run build
  - cargo check --manifest-path src-tauri/Cargo.toml