### PR TITLE
docs: finalize README for public release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a reproducible bug in Tabbed Terminal
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please provide enough detail to reproduce the issue.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+      placeholder: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include exact steps, shortcuts, and pane/workspace context.
+      placeholder: |
+        1. Open app
+        2. Create Pane 2
+        3. Press Cmd+...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshot / log (optional)
+      description: Paste screenshots, terminal output, or stack traces.
+  - type: input
+    id: version
+    attributes:
+      label: App version (or commit)
+      placeholder: v0.2.0 / 1171160
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Internal release task tracking (temporary)
+    url: https://github.com/t-tonton/note/issues
+    about: During internal phase, release tasks are tracked separately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Propose a new feature or UX improvement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please keep scope small and concrete so implementation can be planned as one issue.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What pain point are you facing now?
+      placeholder: Current behavior and why it is insufficient.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the expected UX/behavior in detail.
+      placeholder: UI entry point, shortcut, and expected output.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      placeholder: Any other options you evaluated.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List checkable conditions.
+      placeholder: |
+        - [ ] Works with multiple panes
+        - [ ] No shortcut conflicts
+        - [ ] Covered by tests
+    validations:
+      required: true

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,64 @@
+# Tabbed Terminal
+
+Tauri + React で構築したデスクトップ向けターミナルワークスペースアプリです。
+
+[English README](README.md)
+
+## 主な機能
+
+- 複数ワークスペース（タブ）
+- ワークスペースごとに複数パネル
+- パネルのリネーム / クローズ / リサイズ
+- ネイティブのターミナルコピー＆ペースト（`Cmd/Ctrl + C`, `Cmd/Ctrl + V`）
+- よく使うコマンド用の Snippets Picker
+  - スニペットの保存 / 編集 / 削除
+  - スニペット検索
+  - コマンドをクリップボードへコピー
+
+## ショートカット
+
+- `Cmd/Ctrl + T`: 新しいワークスペース
+- `Cmd/Ctrl + W`: 現在のワークスペースを閉じる
+- `Cmd/Ctrl + N`: 新しいパネル
+- `Cmd/Ctrl + Shift + P`: Snippets Picker を開く
+- `Cmd/Ctrl + 1..9`: 番号でワークスペース切り替え
+- `Cmd/Ctrl + Shift + [` / `]`: 前 / 次のワークスペース
+- `Cmd/Ctrl + =`, `-`, `0`: ズームイン / ズームアウト / リセット
+
+## 既知の制限
+
+- Snippets Picker は現状モーダル表示（表示中は背景操作をロック）
+- スニペットは現時点ではローカルブラウザストレージに保存
+- Vite のビルドで chunk-size warning が出る（リリースブロッカーではない）
+
+## 開発
+
+```bash
+npm install
+npm run tauri dev
+```
+
+## ビルド
+
+```bash
+npm run build
+npm run tauri build
+```
+
+## 品質ゲート
+
+```bash
+npm run lint
+npm run test
+npm run build
+cargo check --manifest-path src-tauri/Cargo.toml
+```
+
+## Issue 報告
+
+- 公開後の不具合報告 / 機能要望はこのリポジトリで管理します。
+- 内部フェーズ中のリリース作業は別途管理します。
+
+## コントリビューションガイド
+
+ブランチ戦略・PRルール・マージ方針は `CONTRIBUTING.md` を参照してください。

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A desktop terminal workspace app built with Tauri + React.
 
+[日本語版 README](README.ja.md)
+
 ## Features
 
 - Multiple workspaces (tabs)


### PR DESCRIPTION
## Summary
- update README with current product features and shortcuts
- document known limitations for current release scope
- add quality-gate commands and issue reporting links
- keep contribution guide link intact

## Related Issue
- note issue: https://github.com/t-tonton/note/issues/15

## Verification
- docs-only change
- pre-push quality gates passed