### PR TITLE
feat: add in-pane find with Cmd/Ctrl+F

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,6 +21,7 @@ Tauri + React で構築したデスクトップ向けターミナルワークス
 - `Cmd/Ctrl + W`: 現在のワークスペースを閉じる
 - `Cmd/Ctrl + N`: 新しいパネル
 - `Cmd/Ctrl + Shift + P`: Snippets Picker を開く
+- `Cmd/Ctrl + F`: フォーカス中のPane内検索
 - `Cmd/Ctrl + 1..9`: 番号でワークスペース切り替え
 - `Cmd/Ctrl + Shift + [` / `]`: 前 / 次のワークスペース
 - `Cmd/Ctrl + =`, `-`, `0`: ズームイン / ズームアウト / リセット

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A desktop terminal workspace app built with Tauri + React.
 - `Cmd/Ctrl + W`: Close current workspace
 - `Cmd/Ctrl + N`: New pane
 - `Cmd/Ctrl + Shift + P`: Open snippets picker
+- `Cmd/Ctrl + F`: Find in focused pane
 - `Cmd/Ctrl + 1..9`: Switch workspace by number
 - `Cmd/Ctrl + Shift + [` / `]`: Previous / next workspace
 - `Cmd/Ctrl + =`, `-`, `0`: Zoom in / out / reset

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+import { useAppStore } from '../stores';
+
+function createWorkspace() {
+  const now = new Date().toISOString();
+  return {
+    id: 'ws-1',
+    name: 'Workspace 1',
+    template: 'blank' as const,
+    projectContext: '',
+    panes: [],
+    layout: { direction: 'horizontal' as const, sizes: [] },
+    promptPresets: [],
+    dirty: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function KeyboardShortcutHarness() {
+  useKeyboardShortcuts();
+  return null;
+}
+
+describe('useKeyboardShortcuts', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [createWorkspace()],
+      activeWorkspaceId: 'ws-1',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens pane search on Cmd/Ctrl+F', () => {
+    const listener = vi.fn();
+    window.addEventListener('pane-search-open', listener);
+
+    render(<KeyboardShortcutHarness />);
+
+    const metaEvent = new KeyboardEvent('keydown', {
+      key: 'f',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(metaEvent);
+
+    const ctrlEvent = new KeyboardEvent('keydown', {
+      key: 'f',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(ctrlEvent);
+
+    expect(metaEvent.defaultPrevented).toBe(true);
+    expect(ctrlEvent.defaultPrevented).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    window.removeEventListener('pane-search-open', listener);
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -17,6 +17,13 @@ export function useKeyboardShortcuts() {
     const handleKeyDown = (e: KeyboardEvent) => {
       const isMod = e.metaKey || e.ctrlKey;
 
+      // Cmd/Ctrl+F: Open in-pane terminal search
+      if (isMod && !e.shiftKey && e.key.toLowerCase() === 'f') {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent('pane-search-open'));
+        return;
+      }
+
       // Cmd+Shift+P: Open snippet picker
       if (isMod && e.shiftKey && e.key.toLowerCase() === 'p') {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- add in-pane find UI for focused terminal pane
- bind Cmd/Ctrl+F to open pane find (instead of browser find)
- support next/previous hit navigation and match counter
- update README (EN/JA) shortcuts
- add keyboard shortcut test for pane-search event

## Related Issue
- Closes #1
- note issue: https://github.com/t-tonton/note/issues/1

## Verification
```bash
npm run lint
npm run test
npm run build
cargo check --manifest-path src-tauri/Cargo.toml
```
