### PR TITLE
feat: add workspace-wide pane history search

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -22,6 +22,7 @@ Tauri + React で構築したデスクトップ向けターミナルワークス
 - `Cmd/Ctrl + N`: 新しいパネル
 - `Cmd/Ctrl + Shift + P`: Snippets Picker を開く
 - `Cmd/Ctrl + F`: フォーカス中のPane内検索
+- `Cmd/Ctrl + Shift + F`: ワークスペース内の全Pane履歴を横断検索
 - `Cmd/Ctrl + 1..9`: 番号でワークスペース切り替え
 - `Cmd/Ctrl + Shift + [` / `]`: 前 / 次のワークスペース
 - `Cmd/Ctrl + =`, `-`, `0`: ズームイン / ズームアウト / リセット

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A desktop terminal workspace app built with Tauri + React.
 - `Cmd/Ctrl + N`: New pane
 - `Cmd/Ctrl + Shift + P`: Open snippets picker
 - `Cmd/Ctrl + F`: Find in focused pane
+- `Cmd/Ctrl + Shift + F`: Search across all pane history in workspaces
 - `Cmd/Ctrl + 1..9`: Switch workspace by number
 - `Cmd/Ctrl + Shift + [` / `]`: Previous / next workspace
 - `Cmd/Ctrl + =`, `-`, `0`: Zoom in / out / reset

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from './components/layout';
+import { WorkspaceSearch } from './features/search';
 import { SnippetPicker } from './features/snippets';
 import { WorkspaceContainer } from './features/workspaces';
 import { useInitialize, useKeyboardShortcuts } from './hooks';
@@ -12,6 +13,7 @@ function App() {
       <AppLayout>
         <WorkspaceContainer />
       </AppLayout>
+      <WorkspaceSearch />
       <SnippetPicker />
     </>
   );

--- a/src/components/layout/IconSidebar.tsx
+++ b/src/components/layout/IconSidebar.tsx
@@ -5,6 +5,7 @@ export function IconSidebar() {
   const activeWorkspaceId = useAppStore((state) => state.activeWorkspaceId);
   const createPane = useAppStore((state) => state.createPane);
   const openSnippetPicker = useAppStore((state) => state.openSnippetPicker);
+  const openWorkspaceSearch = useAppStore((state) => state.openWorkspaceSearch);
   const activeWorkspace = useActiveWorkspace();
   const [settingsActive, setSettingsActive] = useState(false);
 
@@ -39,9 +40,9 @@ export function IconSidebar() {
 
       <SidebarButton
         icon={<SearchIcon />}
-        label="Search"
-        onClick={() => {}}
-        disabled
+        label="Workspace Search"
+        shortcut="⌘⇧F"
+        onClick={openWorkspaceSearch}
       />
 
       <SidebarButton

--- a/src/features/search/components/WorkspaceSearch.tsx
+++ b/src/features/search/components/WorkspaceSearch.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useAppStore } from '../../../stores';
+
+interface SearchResult {
+  workspaceId: string;
+  workspaceName: string;
+  paneId: string;
+  paneTitle: string;
+  lineNumber: number;
+  preview: string;
+}
+
+const MAX_RESULTS = 120;
+
+export function WorkspaceSearch() {
+  const isOpen = useAppStore((state) => state.isWorkspaceSearchOpen);
+  const close = useAppStore((state) => state.closeWorkspaceSearch);
+  const workspaces = useAppStore((state) => state.workspaces);
+  const terminalHistoryByPane = useAppStore((state) => state.terminalHistoryByPane);
+  const setActiveWorkspace = useAppStore((state) => state.setActiveWorkspace);
+  const setFocusedPane = useAppStore((state) => state.setFocusedPane);
+
+  const [query, setQuery] = useState('');
+
+  const handleClose = useCallback(() => {
+    close();
+    setQuery('');
+  }, [close]);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [] as SearchResult[];
+
+    const found: SearchResult[] = [];
+
+    for (const workspace of workspaces) {
+      for (const pane of workspace.panes) {
+        const history = terminalHistoryByPane[pane.id] ?? '';
+        if (!history) continue;
+
+        const lines = history.split('\n');
+        for (let i = 0; i < lines.length; i += 1) {
+          const line = lines[i];
+          if (!line) continue;
+          if (!line.toLowerCase().includes(q)) continue;
+
+          found.push({
+            workspaceId: workspace.id,
+            workspaceName: workspace.name,
+            paneId: pane.id,
+            paneTitle: pane.title,
+            lineNumber: i + 1,
+            preview: line.length > 140 ? `${line.slice(0, 140)}...` : line,
+          });
+
+          if (found.length >= MAX_RESULTS) return found;
+        }
+      }
+    }
+
+    return found;
+  }, [query, terminalHistoryByPane, workspaces]);
+
+  const jumpToResult = useCallback(
+    (result: SearchResult) => {
+      const q = query.trim();
+      setActiveWorkspace(result.workspaceId);
+      setFocusedPane(result.paneId);
+      handleClose();
+
+      setTimeout(() => {
+        window.dispatchEvent(
+          new CustomEvent('pane-search-open', {
+            detail: { paneId: result.paneId, query: q },
+          }),
+        );
+      }, 0);
+    },
+    [handleClose, query, setActiveWorkspace, setFocusedPane],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleClose();
+        return;
+      }
+
+      if (e.key === 'Enter' && results.length > 0) {
+        e.preventDefault();
+        jumpToResult(results[0]);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [handleClose, isOpen, jumpToResult, results]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div style={overlayStyle} onClick={handleClose}>
+      <div style={panelStyle} onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+          <h2 style={{ margin: 0, fontSize: '16px', fontWeight: 600 }}>Workspace Search</h2>
+          <button onClick={handleClose} style={ghostButtonStyle}>Close</button>
+        </div>
+
+        <input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search across pane history..."
+          style={inputStyle}
+        />
+
+        <div style={{ marginTop: '10px', color: 'var(--text-muted)', fontSize: '12px' }}>
+          {query.trim() ? `${results.length} result(s)` : 'Type to search all panes in this app session'}
+        </div>
+
+        <div style={{ display: 'grid', gap: '8px', marginTop: '10px', maxHeight: '56vh', overflowY: 'auto' }}>
+          {results.map((result, index) => (
+            <button
+              key={`${result.workspaceId}-${result.paneId}-${result.lineNumber}-${index}`}
+              onClick={() => jumpToResult(result)}
+              style={resultButtonStyle}
+              title="Open pane and highlight match"
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px' }}>
+                <div style={{ fontSize: '12px', color: '#a7f3d0' }}>{result.workspaceName}</div>
+                <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Line {result.lineNumber}</div>
+              </div>
+              <div style={{ marginTop: '3px', fontSize: '13px', color: 'var(--text-primary)', textAlign: 'left' }}>{result.paneTitle}</div>
+              <div style={{ marginTop: '4px', fontSize: '12px', color: 'var(--text-secondary)', textAlign: 'left', whiteSpace: 'pre-wrap' }}>
+                {result.preview}
+              </div>
+            </button>
+          ))}
+
+          {query.trim() && results.length === 0 ? (
+            <div style={emptyStyle}>No matches in pane history.</div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlayStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(3, 6, 18, 0.46)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 61,
+  backdropFilter: 'blur(2px)',
+};
+
+const panelStyle: CSSProperties = {
+  width: 'min(900px, 92vw)',
+  maxHeight: '84vh',
+  overflow: 'hidden',
+  borderRadius: '12px',
+  border: '1px solid var(--border-default)',
+  background: 'linear-gradient(180deg, #111a33 0%, #0c1328 100%)',
+  boxShadow: '0 20px 60px rgba(0,0,0,0.5)',
+  padding: '14px',
+  color: 'var(--text-primary)',
+};
+
+const inputStyle: CSSProperties = {
+  width: '100%',
+  borderRadius: '8px',
+  border: '1px solid var(--border-default)',
+  background: 'var(--bg-input)',
+  color: 'var(--text-primary)',
+  padding: '8px 10px',
+  fontSize: '13px',
+};
+
+const ghostButtonStyle: CSSProperties = {
+  border: '1px solid var(--border-default)',
+  background: 'transparent',
+  color: 'var(--text-secondary)',
+  borderRadius: '7px',
+  padding: '6px 10px',
+  fontSize: '12px',
+  cursor: 'pointer',
+};
+
+const resultButtonStyle: CSSProperties = {
+  width: '100%',
+  textAlign: 'left',
+  borderRadius: '9px',
+  border: '1px solid var(--border-subtle)',
+  background: 'rgba(255,255,255,0.02)',
+  padding: '10px',
+  cursor: 'pointer',
+};
+
+const emptyStyle: CSSProperties = {
+  borderRadius: '9px',
+  border: '1px dashed var(--border-default)',
+  padding: '12px',
+  color: 'var(--text-muted)',
+  fontSize: '12px',
+};

--- a/src/features/search/index.ts
+++ b/src/features/search/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceSearch } from './components/WorkspaceSearch';

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -29,6 +29,7 @@ describe('useKeyboardShortcuts', () => {
     useAppStore.setState({
       workspaces: [createWorkspace()],
       activeWorkspaceId: 'ws-1',
+      isWorkspaceSearchOpen: false,
     });
   });
 
@@ -63,5 +64,34 @@ describe('useKeyboardShortcuts', () => {
     expect(listener).toHaveBeenCalledTimes(2);
 
     window.removeEventListener('pane-search-open', listener);
+  });
+
+  it('opens workspace search on Cmd/Ctrl+Shift+F', () => {
+    render(<KeyboardShortcutHarness />);
+
+    const metaEvent = new KeyboardEvent('keydown', {
+      key: 'F',
+      metaKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(metaEvent);
+    expect(metaEvent.defaultPrevented).toBe(true);
+    expect(useAppStore.getState().isWorkspaceSearchOpen).toBe(true);
+
+    useAppStore.setState({ isWorkspaceSearchOpen: false });
+
+    const ctrlEvent = new KeyboardEvent('keydown', {
+      key: 'f',
+      ctrlKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(ctrlEvent);
+
+    expect(ctrlEvent.defaultPrevented).toBe(true);
+    expect(useAppStore.getState().isWorkspaceSearchOpen).toBe(true);
   });
 });

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -12,6 +12,7 @@ export function useKeyboardShortcuts() {
   const zoomOut = useAppStore((state) => state.zoomOut);
   const resetZoom = useAppStore((state) => state.resetZoom);
   const openSnippetPicker = useAppStore((state) => state.openSnippetPicker);
+  const openWorkspaceSearch = useAppStore((state) => state.openWorkspaceSearch);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -21,6 +22,13 @@ export function useKeyboardShortcuts() {
       if (isMod && !e.shiftKey && e.key.toLowerCase() === 'f') {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent('pane-search-open'));
+        return;
+      }
+
+      // Cmd/Ctrl+Shift+F: Open workspace-wide search
+      if (isMod && e.shiftKey && e.key.toLowerCase() === 'f') {
+        e.preventDefault();
+        openWorkspaceSearch();
         return;
       }
 
@@ -150,5 +158,6 @@ export function useKeyboardShortcuts() {
     zoomOut,
     resetZoom,
     openSnippetPicker,
+    openWorkspaceSearch,
   ]);
 }

--- a/src/stores/slices/layoutSlice.ts
+++ b/src/stores/slices/layoutSlice.ts
@@ -8,6 +8,7 @@ export interface LayoutSlice {
   isNewPaneModalOpen: boolean;
   isPaneSwitcherOpen: boolean;
   isSnippetPickerOpen: boolean;
+  isWorkspaceSearchOpen: boolean;
   editingPaneId: string | null;
 
   // Actions
@@ -23,6 +24,8 @@ export interface LayoutSlice {
   closePaneEditor: () => void;
   openSnippetPicker: () => void;
   closeSnippetPicker: () => void;
+  openWorkspaceSearch: () => void;
+  closeWorkspaceSearch: () => void;
 }
 
 export const createLayoutSlice: StateCreator<
@@ -36,6 +39,7 @@ export const createLayoutSlice: StateCreator<
   isNewPaneModalOpen: false,
   isPaneSwitcherOpen: false,
   isSnippetPickerOpen: false,
+  isWorkspaceSearchOpen: false,
   editingPaneId: null,
 
   toggleSideDrawer: () => {
@@ -84,5 +88,13 @@ export const createLayoutSlice: StateCreator<
 
   closeSnippetPicker: () => {
     set({ isSnippetPickerOpen: false });
+  },
+
+  openWorkspaceSearch: () => {
+    set({ isWorkspaceSearchOpen: true });
+  },
+
+  closeWorkspaceSearch: () => {
+    set({ isWorkspaceSearchOpen: false });
   },
 });

--- a/src/stores/slices/zustandSlices.test.ts
+++ b/src/stores/slices/zustandSlices.test.ts
@@ -23,6 +23,8 @@ beforeEach(() => {
     activeWorkspaceId: null,
     focusedPaneId: null,
     sendingPaneIds: new Set<string>(),
+    terminalHistoryByPane: {},
+    isWorkspaceSearchOpen: false,
   });
 });
 
@@ -61,6 +63,7 @@ describe('panesSlice', () => {
     useAppStore.setState({
       workspaces: [makeWorkspace('ws-1', 'Workspace 1')],
       activeWorkspaceId: 'ws-1',
+      terminalHistoryByPane: {},
     });
   });
 
@@ -114,5 +117,19 @@ describe('panesSlice', () => {
     expect(duplicated).toBeDefined();
     expect(duplicated?.title).toBe('Pane 1 (Copy)');
     expect(duplicated?.messages).toHaveLength(0);
+  });
+
+  it('stores terminal output per pane and clears it when pane is deleted', () => {
+    const paneId = useAppStore.getState().createPane('ws-1', { title: 'Pane 1' });
+
+    useAppStore.getState().appendTerminalOutput(paneId, 'hello');
+    useAppStore.getState().appendTerminalOutput(paneId, '\nworld');
+
+    expect(useAppStore.getState().terminalHistoryByPane[paneId]).toContain('hello');
+    expect(useAppStore.getState().terminalHistoryByPane[paneId]).toContain('world');
+
+    useAppStore.getState().deletePane('ws-1', paneId);
+
+    expect(useAppStore.getState().terminalHistoryByPane[paneId]).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Add workspace-wide pane history search UI and state wiring
- Allow opening search from keyboard shortcut and sidebar action
- Persist pane outputs needed for cross-pane search

## Changes
- add `WorkspaceSearch` feature component and connect it in `App`
- add search toggle action in `IconSidebar`
- extend pane store/layout store to support workspace search behavior
- update `Terminal`/pane state handling to collect searchable history
- add tests for keyboard shortcut and zustand slice behavior
- update README (`README.md`, `README.ja.md`) with the new search feature

## Verification
```bash
npm run lint
npm run test
npm run build
cargo check --manifest-path src-tauri/Cargo.toml
```
