### PR TITLE
feat: add workspace save and restore workflow

### DIFF
--- a/src/hooks/useInitialize.test.tsx
+++ b/src/hooks/useInitialize.test.tsx
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { useInitialize } from './useInitialize';
+import { useAppStore } from '../stores';
+
+function InitializeHarness() {
+  useInitialize();
+  return null;
+}
+
+describe('useInitialize', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAppStore.setState({
+      workspaces: [],
+      activeWorkspaceId: null,
+      focusedPaneId: null,
+      sendingPaneIds: new Set<string>(),
+      terminalHistoryByPane: {},
+      isWorkspaceSearchOpen: false,
+    });
+  });
+
+  it('creates default workspace and pane when no snapshot exists', () => {
+    render(<InitializeHarness />);
+
+    const state = useAppStore.getState();
+    expect(state.workspaces).toHaveLength(1);
+    expect(state.workspaces[0].name).toBe('Workspace 1');
+    expect(state.workspaces[0].panes).toHaveLength(1);
+    expect(state.workspaces[0].dirty).toBe(false);
+  });
+
+  it('loads workspace snapshot from localStorage', () => {
+    const now = new Date().toISOString();
+    localStorage.setItem(
+      'tabbed-terminal.workspace-state.v1',
+      JSON.stringify({
+        version: 1,
+        savedAt: now,
+        activeWorkspaceId: 'ws-a',
+        workspaces: [
+          {
+            id: 'ws-a',
+            name: 'Restored Workspace',
+            template: 'blank',
+            projectContext: '',
+            panes: [],
+            layout: { direction: 'horizontal', sizes: [] },
+            promptPresets: [],
+            dirty: false,
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      })
+    );
+
+    render(<InitializeHarness />);
+
+    const state = useAppStore.getState();
+    expect(state.workspaces).toHaveLength(1);
+    expect(state.workspaces[0].id).toBe('ws-a');
+    expect(state.workspaces[0].name).toBe('Restored Workspace');
+    expect(state.activeWorkspaceId).toBe('ws-a');
+  });
+});

--- a/src/hooks/useInitialize.ts
+++ b/src/hooks/useInitialize.ts
@@ -1,14 +1,26 @@
 import { useEffect, useRef } from 'react';
+import { loadWorkspaceSnapshot } from '../services/persistence';
 import { useAppStore } from '../stores';
 
 export function useInitialize() {
   const workspaces = useAppStore((state) => state.workspaces);
   const createWorkspace = useAppStore((state) => state.createWorkspace);
   const createPane = useAppStore((state) => state.createPane);
+  const markClean = useAppStore((state) => state.markClean);
   const initializedRef = useRef(false);
 
   useEffect(() => {
     if (initializedRef.current) return;
+
+    const snapshot = loadWorkspaceSnapshot();
+    if (snapshot && snapshot.workspaces.length > 0) {
+      useAppStore.setState({
+        workspaces: snapshot.workspaces,
+        activeWorkspaceId: snapshot.activeWorkspaceId,
+      });
+      initializedRef.current = true;
+      return;
+    }
 
     // Create default workspace if none exists
     if (workspaces.length === 0) {
@@ -16,8 +28,9 @@ export function useInitialize() {
 
       // Create a default pane
       createPane(workspaceId, { title: 'Pane 1' });
+      markClean(workspaceId);
     }
 
     initializedRef.current = true;
-  }, [workspaces.length, createWorkspace, createPane]);
+  }, [workspaces.length, createWorkspace, createPane, markClean]);
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { saveWorkspaceSnapshot } from '../services/persistence';
 import { useAppStore } from '../stores';
 
 export function useKeyboardShortcuts() {
@@ -13,6 +14,7 @@ export function useKeyboardShortcuts() {
   const resetZoom = useAppStore((state) => state.resetZoom);
   const openSnippetPicker = useAppStore((state) => state.openSnippetPicker);
   const openWorkspaceSearch = useAppStore((state) => state.openWorkspaceSearch);
+  const markClean = useAppStore((state) => state.markClean);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -63,6 +65,27 @@ export function useKeyboardShortcuts() {
           createPane(activeWorkspaceId, {
             title: `Pane ${(workspace?.panes.length ?? 0) + 1}`,
           });
+        }
+        return;
+      }
+
+      // Cmd/Ctrl+S: Save workspace snapshot
+      if (isMod && e.key === 's') {
+        e.preventDefault();
+        const workspacesToSave = workspaces.map((workspace) => ({
+          ...workspace,
+          dirty: false,
+        }));
+        const saved = saveWorkspaceSnapshot({
+          workspaces: workspacesToSave,
+          activeWorkspaceId,
+        });
+        if (saved) {
+          for (const workspace of workspaces) {
+            if (workspace.dirty) {
+              markClean(workspace.id);
+            }
+          }
         }
         return;
       }
@@ -153,5 +176,6 @@ export function useKeyboardShortcuts() {
     resetZoom,
     openSnippetPicker,
     openWorkspaceSearch,
+    markClean,
   ]);
 }

--- a/src/services/persistence/index.ts
+++ b/src/services/persistence/index.ts
@@ -1,0 +1,2 @@
+export { loadWorkspaceSnapshot, saveWorkspaceSnapshot } from './workspacePersistence';
+export type { WorkspaceSnapshot } from './workspacePersistence';

--- a/src/services/persistence/workspacePersistence.ts
+++ b/src/services/persistence/workspacePersistence.ts
@@ -1,0 +1,56 @@
+import type { Workspace } from '../../types';
+
+const WORKSPACE_STATE_KEY = 'tabbed-terminal.workspace-state.v1';
+
+interface PersistedWorkspaceStateV1 {
+  version: 1;
+  savedAt: string;
+  activeWorkspaceId: string | null;
+  workspaces: Workspace[];
+}
+
+export interface WorkspaceSnapshot {
+  activeWorkspaceId: string | null;
+  workspaces: Workspace[];
+}
+
+export function saveWorkspaceSnapshot(snapshot: WorkspaceSnapshot): boolean {
+  try {
+    const payload: PersistedWorkspaceStateV1 = {
+      version: 1,
+      savedAt: new Date().toISOString(),
+      activeWorkspaceId: snapshot.activeWorkspaceId,
+      workspaces: snapshot.workspaces,
+    };
+    localStorage.setItem(WORKSPACE_STATE_KEY, JSON.stringify(payload));
+    return true;
+  } catch (error) {
+    console.error('[workspacePersistence] Failed to save workspace snapshot', error);
+    return false;
+  }
+}
+
+export function loadWorkspaceSnapshot(): WorkspaceSnapshot | null {
+  try {
+    const raw = localStorage.getItem(WORKSPACE_STATE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<PersistedWorkspaceStateV1>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.workspaces)) {
+      return null;
+    }
+
+    const activeWorkspaceId =
+      parsed.activeWorkspaceId && parsed.workspaces.some((w) => w.id === parsed.activeWorkspaceId)
+        ? parsed.activeWorkspaceId
+        : parsed.workspaces[0]?.id ?? null;
+
+    return {
+      activeWorkspaceId,
+      workspaces: parsed.workspaces,
+    };
+  } catch (error) {
+    console.error('[workspacePersistence] Failed to load workspace snapshot', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- persist workspace snapshot with Cmd/Ctrl+S
- restore saved workspace state on app startup
- mark default initial workspace as clean after bootstrapping

## Changes
- add persistence service backed by localStorage (`workspacePersistence`)
- wire `useKeyboardShortcuts` Cmd/Ctrl+S to save and clear dirty flags
- wire `useInitialize` to restore saved snapshot before creating defaults
- add initialization and keyboard shortcut tests for save/restore behavior

## Verification
```bash
npm run lint
npm run test
npm run build
cargo check --manifest-path src-tauri/Cargo.toml
```
