### PR TITLE
chore: prepare v0.2.0 release docs and versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## v0.2.0 - 2026-02-18
+
+### Added
+- Workspace-wide pane history search (`Cmd/Ctrl + Shift + F`) with result navigation.
+- In-pane search (`Cmd/Ctrl + F`) for terminal output.
+- Workspace save and restore workflow via `Cmd/Ctrl + S` and startup restore.
+- Test coverage for keyboard shortcuts, initialization flow, TabBar behavior, and store slices.
+- Local quality gates and CI checks to run lint/test/build/cargo-check consistently.
+
+### Fixed
+- Workspace close behavior to avoid blocked close actions in dirty state.
+- Tab close affordance visibility improvements in the tab bar.
+- Pane terminal history handling and related search wiring stability.

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,7 @@ Tauri + React で構築したデスクトップ向けターミナルワークス
 - `Cmd/Ctrl + T`: 新しいワークスペース
 - `Cmd/Ctrl + W`: 現在のワークスペースを閉じる
 - `Cmd/Ctrl + N`: 新しいパネル
+- `Cmd/Ctrl + S`: 現在のワークスペース状態を保存
 - `Cmd/Ctrl + Shift + P`: Snippets Picker を開く
 - `Cmd/Ctrl + F`: フォーカス中のPane内検索
 - `Cmd/Ctrl + Shift + F`: ワークスペース内の全Pane履歴を横断検索
@@ -31,6 +32,7 @@ Tauri + React で構築したデスクトップ向けターミナルワークス
 
 - Snippets Picker は現状モーダル表示（表示中は背景操作をロック）
 - スニペットは現時点ではローカルブラウザストレージに保存
+- ワークスペース保存/復元は現時点で localStorage ベース（Tauri fs 化は今後対応）
 - Vite のビルドで chunk-size warning が出る（リリースブロッカーではない）
 
 ## 開発

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A desktop terminal workspace app built with Tauri + React.
 - `Cmd/Ctrl + T`: New workspace
 - `Cmd/Ctrl + W`: Close current workspace
 - `Cmd/Ctrl + N`: New pane
+- `Cmd/Ctrl + S`: Save current workspace snapshot
 - `Cmd/Ctrl + Shift + P`: Open snippets picker
 - `Cmd/Ctrl + F`: Find in focused pane
 - `Cmd/Ctrl + Shift + F`: Search across all pane history in workspaces
@@ -31,6 +32,7 @@ A desktop terminal workspace app built with Tauri + React.
 
 - Snippets picker is currently modal (background is locked while open)
 - Snippets are stored in local browser storage for now
+- Workspace save/restore currently uses local storage (Tauri fs persistence is planned)
 - Build shows chunk-size warning in Vite output (not a release blocker)
 
 ## Development

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'src-tauri/target/**']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabbed-terminal",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1 --port 5173 --strictPort",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "log",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Tabbed Terminal",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.tabbed-terminal.ide",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- update release docs for current feature set and shortcuts
- add `CHANGELOG.md` with `v0.2.0` section
- bump project version to `0.2.0` across app/package configs
- ignore `src-tauri/target` in ESLint to avoid generated-file parse failures

## Included for note issues
- #15 README finalization
- #16 CHANGELOG creation
- #17 version update and build artifact verification

## Verification
```bash
npm run check:full
npm run tauri build -- --bundles app
```

## Notes
- `npm run tauri build` (default bundles) reaches app bundle build, but DMG bundling fails in this environment at `bundle_dmg.sh`.
- Confirmed generated app bundle:
  - `src-tauri/target/release/bundle/macos/Tabbed Terminal.app`
