### PR TITLE
chore: align feature issue template label with feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature request
 description: Propose a new feature or UX improvement
 title: "feat: "
 labels:
-  - enhancement
+  - feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary
- update feature issue template auto-label from `enhancement` to `feature`
- keep bug template unchanged (`bug`)

## Why
- ensure issue template choice maps directly to the expected label taxonomy

## Verification
- opened `.github/ISSUE_TEMPLATE/feature_request.yml` and confirmed:
  - `labels: [feature]`
