### PR TITLE
ci: enforce release labels and auto-draft releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,9 @@
 - Closes #
 - note issue: https://github.com/t-tonton/note/issues/
 
+## Release Label
+- Set exactly one: `release:major` / `release:minor` / `release:patch`
+
 ## Verification
 ```bash
 npm run lint
@@ -21,6 +24,7 @@ cargo check --manifest-path src-tauri/Cargo.toml
 - After:
 
 ## Checklist
+- [ ] I set exactly one release label (`release:major` / `release:minor` / `release:patch`)
 - [ ] I confirmed local app startup (`npm run tauri dev`)
 - [ ] I ran lint/test/build successfully
 - [ ] I ran `cargo check` successfully

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+no-changes-template: '- No user-facing changes in this cycle.'
+template: |
+  ## Changes
+  $CHANGES
+
+categories:
+  - title: 'Features'
+    labels:
+      - feature
+  - title: 'Fixes'
+    labels:
+      - bug
+  - title: 'Maintenance'
+    labels:
+      - chore
+      - documentation
+
+version-resolver:
+  major:
+    labels:
+      - 'release:major'
+  minor:
+    labels:
+      - 'release:minor'
+  patch:
+    labels:
+      - 'release:patch'
+  default: patch
+
+exclude-labels:
+  - skip-changelog

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-label-check.yml
+++ b/.github/workflows/release-label-check.yml
@@ -1,0 +1,27 @@
+name: Release Label Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+
+jobs:
+  require-release-label:
+    name: Require release:* label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const required = ['release:major', 'release:minor', 'release:patch'];
+            const labels = context.payload.pull_request.labels.map((l) => l.name);
+            const matched = required.filter((name) => labels.includes(name));
+
+            if (matched.length !== 1) {
+              core.setFailed(
+                `Exactly one release label is required: ${required.join(', ')}. ` +
+                `Current labels: ${labels.join(', ') || '(none)'}`
+              );
+            } else {
+              core.info(`Release label check passed: ${matched[0]}`);
+            }


### PR DESCRIPTION
## Summary
- add required PR check for exactly one `release:*` label
- add Release Drafter workflow to auto-update draft release on main/PR events
- configure semver resolver priority: `release:major` > `release:minor` > `release:patch`
- update PR template to remind release-label selection

## Included setup
- created repository labels:
  - `release:major`
  - `release:minor`
  - `release:patch`

## Verification
- `npm run check:full`
- reviewed workflow/config files:
  - `.github/workflows/release-label-check.yml`
  - `.github/workflows/release-drafter.yml`
  - `.github/release-drafter.yml`
