### PR TITLE
fix: stabilize release drafter and set v0.2.0 baseline

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+next-version: '0.2.0'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 no-changes-template: '- No user-facing changes in this cycle.'
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,10 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
 
+concurrency:
+  group: release-drafter-${{ github.repository }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: read


### PR DESCRIPTION
## Summary
- prevent duplicate draft release generation by adding workflow concurrency
- set Release Drafter initial `next-version` to `0.2.0`

## Why
- release drafts were being created in duplicate when multiple events fired close together
- first generated draft defaulted to `v0.1.0`, while current release target is `v0.2.0`
