### PR TITLE
ci: consolidate duplicate release drafts

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,3 +25,36 @@ jobs:
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Consolidate draft releases
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const drafts = releases
+              .filter((release) => release.draft)
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            if (drafts.length <= 1) {
+              core.info(`Draft release count is ${drafts.length}. No cleanup needed.`);
+              return;
+            }
+
+            const [latest, ...staleDrafts] = drafts;
+            core.info(`Keeping latest draft #${latest.id} (${latest.tag_name || latest.name}).`);
+
+            for (const release of staleDrafts) {
+              await github.rest.repos.deleteRelease({
+                owner,
+                repo,
+                release_id: release.id,
+              });
+              core.info(`Deleted stale draft #${release.id} (${release.tag_name || release.name}).`);
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ CI must pass on PR:
 - Release draft is auto-updated by `.github/workflows/release-drafter.yml` on:
   - push to `main`
   - PR label/content updates
+- If multiple draft releases exist, workflow keeps only the latest draft automatically.
 - Version bump priority is:
   - `release:major` > `release:minor` > `release:patch`
 


### PR DESCRIPTION
## Summary
- add post-step in Release Drafter workflow to keep only the latest draft release
- delete stale draft releases automatically when duplicates exist
- document this behavior in CONTRIBUTING release automation section

## Verification
- npm run lint
- npm run test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml