### PR TITLE
ci: attach SHA256 checksums to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,19 @@ jobs:
           name: tauri-bundles-macos
           path: src-tauri/target/release/bundle/**
 
+      - name: Generate SHA256 checksums
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          cd src-tauri/target/release/bundle
+          find . -type f \( \
+            -name "*.dmg" -o \
+            -name "*.app.tar.gz" -o \
+            -name "*.app.tar.gz.sig" -o \
+            -name "*.tar.gz" -o \
+            -name "*.sig" \
+          \) -print0 | sort -z | xargs -0 shasum -a 256 > SHA256SUMS.txt
+
       - name: Publish GitHub Release assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
@@ -58,3 +71,4 @@ jobs:
             src-tauri/target/release/bundle/**/*.app.tar.gz.sig
             src-tauri/target/release/bundle/**/*.tar.gz
             src-tauri/target/release/bundle/**/*.sig
+            src-tauri/target/release/bundle/SHA256SUMS.txt


### PR DESCRIPTION
## Summary
- generate SHA256 checksum file for release bundles during tag builds
- upload SHA256SUMS.txt to GitHub Release assets
- keep distribution model focused on GitHub Releases (no Packages publishing)

## Verification
- npm run lint
- npm run test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml