### PR TITLE
ci: remove DMG artifacts from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 concurrency:
@@ -45,7 +45,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tauri-bundles-macos
-          path: src-tauri/target/release/bundle/**
+          path: |
+            src-tauri/target/release/bundle/**
+            !src-tauri/target/release/bundle/**/*.dmg
 
       - name: Generate SHA256 checksums
         if: startsWith(github.ref, 'refs/tags/')
@@ -53,7 +55,6 @@ jobs:
           set -euo pipefail
           cd src-tauri/target/release/bundle
           find . -type f \( \
-            -name "*.dmg" -o \
             -name "*.app.tar.gz" -o \
             -name "*.app.tar.gz.sig" -o \
             -name "*.tar.gz" -o \
@@ -66,7 +67,6 @@ jobs:
         with:
           generate_release_notes: true
           files: |
-            src-tauri/target/release/bundle/**/*.dmg
             src-tauri/target/release/bundle/**/*.app.tar.gz
             src-tauri/target/release/bundle/**/*.app.tar.gz.sig
             src-tauri/target/release/bundle/**/*.tar.gz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,11 @@ CI must pass on PR:
 - Version bump priority is:
   - `release:major` > `release:minor` > `release:patch`
 
+## macOS Release Artifacts
+- Tagged releases (`v*`) in `.github/workflows/release.yml` publish non-DMG artifacts only.
+- DMG files are excluded from CI artifact upload, checksum generation, and GitHub Release assets.
+- Apple Developer Program–dependent notarization is not part of the current release pipeline.
+
 ## Review and Merge Policy
 - At least one reviewer approval is required.
 - Do not merge if unresolved review comments remain.


### PR DESCRIPTION
## Summary
- exclude DMG files from release artifact upload
- remove DMG from checksum generation and GitHub Release assets
- update CONTRIBUTING.md to match the current non-DMG release policy

## Verification
- pre-commit hook: npm run lint
- pre-commit hook: npm run test
- pre-push hook: npm run build
- pre-push hook: cargo check --manifest-path src-tauri/Cargo.toml