### PR TITLE
docs: embed demo video player in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A desktop terminal workspace app built with Tauri + React.
 
 ## Demo
 
+<video src="docs/demo/demo.webm" controls muted loop playsinline width="960"></video>
+
 [Watch demo video](docs/demo/demo.webm)
 
 Local recording command:


### PR DESCRIPTION
## Summary
- switch Demo section to embedded video player (`<video>`)
- keep fallback link to `docs/demo/demo.webm`

## Why
- make demo directly viewable from README without leaving the page