### PR TITLE
chore: bump app version to 0.3.1 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabbed-terminal",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabbed-terminal",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabbed-terminal",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "engines": {
     "node": ">=22.12 <23 || >=24 <25",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "tabbed-terminal"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "log",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabbed-terminal"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Tauri App"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Tabbed Terminal",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.tabbed-terminal.ide",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump app version to 0.3.1 for release build preparation
- sync version across Node, Tauri config, Rust crate, and lock files

## Updated files
- package.json
- package-lock.json
- src-tauri/Cargo.toml
- src-tauri/tauri.conf.json
- src-tauri/Cargo.lock

## Verification
- npm run lint
- cargo check --manifest-path src-tauri/Cargo.toml
- pre-push checks: lint, test, build, cargo check