### PR TITLE
chore: fix release drafter baseline after v0.3.1

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-next-version: '0.2.0'
+next-version: '0.3.1'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 no-changes-template: '- No user-facing changes in this cycle.'
 template: |


### PR DESCRIPTION
## Summary
- update release-drafter next-version from 0.2.0 to 0.3.1
- prevent future draft release version mismatch after publishing v0.3.1

## Verification
- npm run lint
- npm run test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml