### PR TITLE
ci: auto-create version bump PR from release labels

### DIFF
--- a/.github/scripts/bump-version.mjs
+++ b/.github/scripts/bump-version.mjs
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+function writeJson(path, value) {
+  fs.writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseSemver(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) throw new Error(`Invalid semver: ${version}`);
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function bumpSemver(version, bump) {
+  const { major, minor, patch } = parseSemver(version);
+  if (bump === 'major') return `${major + 1}.0.0`;
+  if (bump === 'minor') return `${major}.${minor + 1}.0`;
+  if (bump === 'patch') return `${major}.${minor}.${patch + 1}`;
+  throw new Error(`Unsupported bump type: ${bump}`);
+}
+
+function replaceFirst(text, pattern, replacer, description) {
+  if (!pattern.test(text)) {
+    throw new Error(`Failed to update ${description}`);
+  }
+  pattern.lastIndex = 0;
+  return text.replace(pattern, replacer);
+}
+
+function updateCargoToml(path, newVersion) {
+  const raw = fs.readFileSync(path, 'utf8');
+  const updated = replaceFirst(
+    raw,
+    /(^\[package\][\s\S]*?\nversion\s*=\s*")(\d+\.\d+\.\d+)("\n)/m,
+    `$1${newVersion}$3`,
+    'src-tauri/Cargo.toml package version',
+  );
+  fs.writeFileSync(path, updated);
+}
+
+function updateCargoLock(path, newVersion) {
+  const raw = fs.readFileSync(path, 'utf8');
+  const updated = replaceFirst(
+    raw,
+    /(\[\[package\]\]\nname\s*=\s*"tabbed-terminal"\nversion\s*=\s*")(\d+\.\d+\.\d+)("\n)/m,
+    `$1${newVersion}$3`,
+    'src-tauri/Cargo.lock tabbed-terminal version',
+  );
+  fs.writeFileSync(path, updated);
+}
+
+const bump = process.argv[2];
+if (!bump) {
+  console.error('Usage: node .github/scripts/bump-version.mjs <major|minor|patch>');
+  process.exit(1);
+}
+
+const packageJsonPath = 'package.json';
+const packageLockPath = 'package-lock.json';
+const tauriConfPath = 'src-tauri/tauri.conf.json';
+const cargoTomlPath = 'src-tauri/Cargo.toml';
+const cargoLockPath = 'src-tauri/Cargo.lock';
+
+const packageJson = readJson(packageJsonPath);
+const oldVersion = packageJson.version;
+const newVersion = bumpSemver(oldVersion, bump);
+
+packageJson.version = newVersion;
+writeJson(packageJsonPath, packageJson);
+
+const packageLock = readJson(packageLockPath);
+packageLock.version = newVersion;
+if (packageLock.packages && packageLock.packages['']) {
+  packageLock.packages[''].version = newVersion;
+}
+writeJson(packageLockPath, packageLock);
+
+const tauriConf = readJson(tauriConfPath);
+tauriConf.version = newVersion;
+writeJson(tauriConfPath, tauriConf);
+
+updateCargoToml(cargoTomlPath, newVersion);
+updateCargoLock(cargoLockPath, newVersion);
+
+console.log(`Bumped version: ${oldVersion} -> ${newVersion}`);
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `new_version=${newVersion}\n`);
+}

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,84 @@
+name: Auto Version Bump PR
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-version-bump-pr:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine release bump from labels
+        id: decide
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map((l) => l.name);
+            const title = pr.title || '';
+
+            if (title.toLowerCase().startsWith('chore: bump version to ')) {
+              core.info('Skip: version bump PR merged.');
+              core.setOutput('should_bump', 'false');
+              return;
+            }
+
+            const bump = labels.includes('release:major')
+              ? 'major'
+              : labels.includes('release:minor')
+                ? 'minor'
+                : labels.includes('release:patch')
+                  ? 'patch'
+                  : '';
+
+            if (!bump) {
+              core.info('Skip: no release:* label found.');
+              core.setOutput('should_bump', 'false');
+              return;
+            }
+
+            core.setOutput('should_bump', 'true');
+            core.setOutput('bump', bump);
+
+      - name: Checkout main
+        if: steps.decide.outputs.should_bump == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node
+        if: steps.decide.outputs.should_bump == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Apply version bump
+        if: steps.decide.outputs.should_bump == 'true'
+        id: bump
+        run: node .github/scripts/bump-version.mjs "${{ steps.decide.outputs.bump }}"
+
+      - name: Create version bump PR
+        if: steps.decide.outputs.should_bump == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/auto-version-bump-v${{ steps.bump.outputs.new_version }}
+          title: chore: bump version to ${{ steps.bump.outputs.new_version }}
+          body: |
+            ## Summary
+            - auto-generated version bump PR based on merged PR label `${{ steps.decide.outputs.bump }}`
+            - updates Node/Tauri/Rust version fields consistently
+
+            ## Source
+            - merged PR: #${{ github.event.pull_request.number }}
+          labels: |
+            release:patch
+          commit-message: chore: bump version to ${{ steps.bump.outputs.new_version }}
+          delete-branch: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,9 @@ CI must pass on PR:
 - If multiple draft releases exist, workflow keeps only the latest draft automatically.
 - Version bump priority is:
   - `release:major` > `release:minor` > `release:patch`
+- After a PR with `release:*` label is merged into `main`, `.github/workflows/auto-version-bump.yml` opens a version bump PR automatically.
+- Auto-generated version bump PR title format: `chore: bump version to X.Y.Z`
+- Do not remove `release:*` labels from normal PRs; they drive semver bump automation.
 
 ## macOS Release Artifacts
 - Tagged releases (`v*`) in `.github/workflows/release.yml` publish non-DMG artifacts only.


### PR DESCRIPTION
## Summary
- add auto version bump workflow triggered when a PR with release:* label is merged to main
- add repository script to bump version consistently across Node/Tauri/Rust files
- guard against infinite loops by skipping auto-generated version bump PR merges
- document the new automation in CONTRIBUTING.md

## Behavior
- release:major -> major bump
- release:minor -> minor bump
- release:patch -> patch bump

## Verification
- node --check .github/scripts/bump-version.mjs
- npm run lint
- npm run test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml