### PR TITLE
feat: add unread badges for inactive panes and tabs

### DIFF
--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, beforeEach } from 'vitest';
 import { TabBar } from './TabBar';
 import { useAppStore } from '../../stores';
+import { DEFAULT_MODEL_CONFIG } from '../../utils';
 
 function createWorkspace(id: string, name: string, dirty = false) {
   const now = new Date().toISOString();
@@ -20,6 +21,18 @@ function createWorkspace(id: string, name: string, dirty = false) {
   };
 }
 
+function createPane(id: string, title: string) {
+  return {
+    id,
+    title,
+    systemPrompt: '',
+    injectContext: true,
+    messages: [],
+    modelConfig: { ...DEFAULT_MODEL_CONFIG },
+    layout: { x: 0, y: 0, w: 1, h: 1 },
+  };
+}
+
 describe('TabBar rename behavior', () => {
   beforeEach(() => {
     useAppStore.setState({
@@ -28,6 +41,7 @@ describe('TabBar rename behavior', () => {
         createWorkspace('ws-2', 'Workspace 2'),
       ],
       activeWorkspaceId: 'ws-1',
+      unreadCountByPane: {},
     });
   });
 
@@ -106,6 +120,22 @@ describe('TabBar rename behavior', () => {
 
     expect(useAppStore.getState().workspaces).toHaveLength(1);
     expect(useAppStore.getState().workspaces[0].id).toBe('ws-2');
+  });
+
+  it('shows unread badge per workspace', () => {
+    useAppStore.setState({
+      workspaces: [
+        {
+          ...createWorkspace('ws-1', 'Workspace 1'),
+          panes: [createPane('pane-1', 'Pane 1')],
+        },
+        createWorkspace('ws-2', 'Workspace 2'),
+      ],
+      unreadCountByPane: { 'pane-1': 2 },
+    });
+
+    render(<TabBar />);
+    expect(screen.getByLabelText('Workspace 1 unread 2')).toBeInTheDocument();
   });
 
 });

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -19,6 +19,7 @@ import type { Workspace } from '../../types';
 export function TabBar() {
   const workspaces = useAppStore((state) => state.workspaces);
   const activeWorkspaceId = useAppStore((state) => state.activeWorkspaceId);
+  const unreadCountByPane = useAppStore((state) => state.unreadCountByPane);
   const setActiveWorkspace = useAppStore((state) => state.setActiveWorkspace);
   const createWorkspace = useAppStore((state) => state.createWorkspace);
   const deleteWorkspace = useAppStore((state) => state.deleteWorkspace);
@@ -88,6 +89,10 @@ export function TabBar() {
             <WorkspaceTab
               key={workspace.id}
               workspace={workspace}
+              unreadCount={workspace.panes.reduce(
+                (sum, pane) => sum + (unreadCountByPane[pane.id] ?? 0),
+                0
+              )}
               isActive={workspace.id === activeWorkspaceId}
               isHovered={workspace.id === hoveredTabId}
               isEditing={editingTabId === workspace.id}
@@ -147,6 +152,7 @@ export function TabBar() {
 
 interface WorkspaceTabProps {
   workspace: Workspace;
+  unreadCount: number;
   isActive: boolean;
   isHovered: boolean;
   isEditing: boolean;
@@ -164,6 +170,7 @@ interface WorkspaceTabProps {
 
 function WorkspaceTab({
   workspace,
+  unreadCount,
   isActive,
   isHovered,
   isEditing,
@@ -294,6 +301,28 @@ function WorkspaceTab({
           title="Double-click to rename"
         >
           {workspace.name}
+        </span>
+      )}
+
+      {unreadCount > 0 && (
+        <span
+          aria-label={`${workspace.name} unread ${unreadCount}`}
+          style={{
+            minWidth: '18px',
+            height: '18px',
+            borderRadius: '999px',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '0 6px',
+            fontSize: '11px',
+            fontWeight: 700,
+            color: '#0b1225',
+            backgroundColor: '#fbbf24',
+            flexShrink: 0,
+          }}
+        >
+          {unreadCount > 99 ? '99+' : unreadCount}
         </span>
       )}
 

--- a/src/features/panes/components/Pane.tsx
+++ b/src/features/panes/components/Pane.tsx
@@ -17,6 +17,7 @@ export function Pane({ workspaceId, paneId, title, dragHandleProps }: PaneProps)
   const updatePane = useAppStore((state) => state.updatePane);
   const focusedPaneId = useAppStore((state) => state.focusedPaneId);
   const setFocusedPane = useAppStore((state) => state.setFocusedPane);
+  const unreadCount = useAppStore((state) => state.unreadCountByPane[paneId] ?? 0);
 
   const isFocused = focusedPaneId === paneId;
 
@@ -131,6 +132,19 @@ export function Pane({ workspaceId, paneId, title, dragHandleProps }: PaneProps)
               <path d="M4 4l8 8M12 4l-8 8" />
             </svg>
           </button>
+          {unreadCount > 0 && !isFocused && (
+            <span
+              title={`${unreadCount} unread output`}
+              style={{
+                width: '8px',
+                height: '8px',
+                borderRadius: '50%',
+                backgroundColor: '#fbbf24',
+                boxShadow: '0 0 0 2px rgba(251, 191, 36, 0.2)',
+                flexShrink: 0,
+              }}
+            />
+          )}
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- add unread tracking per pane when terminal output arrives on inactive panes
- clear unread state when a pane is focused
- show unread indicator on pane headers and aggregated unread badge on workspace tabs
- clean up pane-related unread/history state on pane/workspace deletion
- add store and UI tests for unread behavior

Closes #49

## Verification
- npm run lint
- npm run test -- src/stores/slices/zustandSlices.test.ts src/components/layout/TabBar.test.tsx
- npm run test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml