### PR TITLE
chore: bump version to 0.4.0 and update changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-next-version: '0.3.1'
+next-version: '0.4.1'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 no-changes-template: '- No user-facing changes in this cycle.'
 template: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented in this file.
 
+## v0.4.0 - 2026-02-22
+
+### Added
+- Unread indicators for inactive panes and tab-level unread count badges.
+- Initial focus handling for newly created/switching workspaces to reduce missed context.
+
+### Fixed
+- False unread notifications on initial/empty terminal output chunks.
+- Pane close button usability (larger hit area, drag interference prevention, icon/hit-area alignment).
+- Pane resize behavior for symmetric left-right resizing and top-edge expansion.
+- Drag preview sizing mismatch during pane move operations.
+
 ## v0.2.0 - 2026-02-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabbed-terminal",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabbed-terminal",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabbed-terminal",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "engines": {
     "node": ">=22.12 <23 || >=24 <25",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabbed-terminal"
-version = "0.3.1"
+version = "0.4.0"
 description = "A Tauri App"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Tabbed Terminal",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "identifier": "com.tabbed-terminal.ide",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump app version to 0.4.0 across web and tauri metadata
- add changelog entry for v0.4.0 (unread badges and follow-up fixes)
- set release-drafter next-version to 0.4.1

## Verification
- npm run lint
- npm run test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml