### PR TITLE
ci: remove draft wording from minor release name

### DIFF
--- a/.github/minor-release-drafter.yml
+++ b/.github/minor-release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: 'Minor line draft: v$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION'
 tag-template: 'minor-v$RESOLVED_VERSION'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 no-changes-template: '- No user-facing changes in this cycle.'


### PR DESCRIPTION
## Summary
- update minor release drafter `name-template` from `Minor line draft: v$RESOLVED_VERSION` to `v$RESOLVED_VERSION`
- keep `tag-template` as `minor-v$RESOLVED_VERSION` for branch-line tracking

## Why
Published minor releases should not keep `draft` wording in the release title.

## Verification
- npm run lint
- npm run test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
