### PR TITLE
feat: configurable pane grid size (3x3/4x4)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,7 @@ Tauri + React で構築したデスクトップ向けターミナルワークス
 - タブのドラッグ＆ドロップによるワークスペース並び替え
 - ワークスペースごとに複数ペイン
 - ペインのリネーム / クローズ / リサイズ
+- ペイングリッドサイズの切り替え（`3x3` / `4x4`）
 - ネイティブのターミナルコピー＆ペースト（`Cmd/Ctrl + C`, `Cmd/Ctrl + V`）
 - よく使うコマンド用の Snippets Picker
   - スニペットの保存 / 編集 / 削除
@@ -25,6 +26,7 @@ Tauri + React で構築したデスクトップ向けターミナルワークス
 - `Cmd/Ctrl + W`: 現在のワークスペースを閉じる
 - `Cmd/Ctrl + N`: 新しいペイン
 - `Cmd/Ctrl + Shift + P`: Snippets Picker を開く
+- `Cmd/Ctrl + Shift + G`: グリッド設定（`3x3` / `4x4`）を開く
 - `Cmd/Ctrl + Shift + R`: Relay ウィンドウを開く
 - `Cmd/Ctrl + F`: フォーカス中のPane内検索
 - `Cmd/Ctrl + Shift + F`: ワークスペース内の全Pane履歴を横断検索

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A desktop terminal workspace app built with Tauri + React.
 - Reorder workspace tabs with drag and drop
 - Multiple panes per workspace
 - Pane rename / close / resize
+- Configurable pane grid size (`3x3` / `4x4`)
 - Native terminal copy & paste (`Cmd/Ctrl + C`, `Cmd/Ctrl + V`)
 - Snippets picker for frequently used commands
   - Save / edit / delete snippets
@@ -38,6 +39,7 @@ The generated file is saved to `docs/demo/demo.webm`.
 - `Cmd/Ctrl + W`: Close current workspace
 - `Cmd/Ctrl + N`: New pane
 - `Cmd/Ctrl + Shift + P`: Open snippets picker
+- `Cmd/Ctrl + Shift + G`: Open grid settings (`3x3` / `4x4`)
 - `Cmd/Ctrl + Shift + R`: Open relay window
 - `Cmd/Ctrl + F`: Find in focused pane
 - `Cmd/Ctrl + Shift + F`: Search across all pane history in workspaces

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from './components/layout';
+import { GridSettingsPanel } from './features/settings';
 import { WorkspaceSearch } from './features/search';
 import { SnippetPicker } from './features/snippets';
 import { RelayPanel, useRelayStateBridge } from './features/relay';
@@ -19,6 +20,7 @@ function App() {
       </AppLayout>
       <WorkspaceSearch />
       <SnippetPicker />
+      <GridSettingsPanel />
       {!isTauriRuntime && <RelayPanel />}
     </>
   );

--- a/src/components/layout/IconSidebar.tsx
+++ b/src/components/layout/IconSidebar.tsx
@@ -5,6 +5,7 @@ export function IconSidebar() {
   const activeWorkspaceId = useAppStore((state) => state.activeWorkspaceId);
   const createPane = useAppStore((state) => state.createPane);
   const openSnippetPicker = useAppStore((state) => state.openSnippetPicker);
+  const openGridSettings = useAppStore((state) => state.openGridSettings);
   const openWorkspaceSearch = useAppStore((state) => state.openWorkspaceSearch);
   const openRelayPanel = useAppStore((state) => state.openRelayPanel);
   const activeWorkspace = useActiveWorkspace();
@@ -60,6 +61,13 @@ export function IconSidebar() {
         label="Snippets"
         shortcut="⌘⇧P"
         onClick={openSnippetPicker}
+      />
+
+      <SidebarButton
+        icon={<GridIcon />}
+        label="Grid Settings"
+        shortcut="⌘⇧G"
+        onClick={openGridSettings}
       />
 
       <SidebarButton
@@ -150,6 +158,17 @@ function RelayIcon() {
       <path d="M8 12L6 10m2 2l-2 2" />
       <circle cx="3" cy="6" r="1" fill="currentColor" stroke="none" />
       <circle cx="15" cy="12" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function GridIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="4" height="4" rx="0.6" />
+      <rect x="11" y="3" width="4" height="4" rx="0.6" />
+      <rect x="3" y="11" width="4" height="4" rx="0.6" />
+      <rect x="11" y="11" width="4" height="4" rx="0.6" />
     </svg>
   );
 }

--- a/src/features/settings/components/GridSettingsPanel.tsx
+++ b/src/features/settings/components/GridSettingsPanel.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties } from 'react';
+import { useAppStore } from '../../../stores';
+
+export function GridSettingsPanel() {
+  const isOpen = useAppStore((state) => state.isGridSettingsOpen);
+  const close = useAppStore((state) => state.closeGridSettings);
+  const paneGridSize = useAppStore((state) => state.paneGridSize);
+  const setPaneGridSize = useAppStore((state) => state.setPaneGridSize);
+
+  if (!isOpen) return null;
+
+  return (
+    <div style={overlayStyle} onClick={close}>
+      <div style={panelStyle} onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h2 style={{ margin: 0, fontSize: '16px', fontWeight: 600 }}>Grid Settings</h2>
+          <button style={ghostButtonStyle} onClick={close}>Close</button>
+        </div>
+
+        <div style={{ marginTop: '12px', display: 'grid', gap: '8px' }}>
+          <label style={optionStyle}>
+            <input
+              type="radio"
+              name="pane-grid-size"
+              checked={paneGridSize === 3}
+              onChange={() => setPaneGridSize(3)}
+            />
+            <span>3 x 3 (max 9 panes)</span>
+          </label>
+          <label style={optionStyle}>
+            <input
+              type="radio"
+              name="pane-grid-size"
+              checked={paneGridSize === 4}
+              onChange={() => setPaneGridSize(4)}
+            />
+            <span>4 x 4 (max 16 panes)</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlayStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(3, 6, 18, 0.48)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 60,
+  backdropFilter: 'blur(2px)',
+};
+
+const panelStyle: CSSProperties = {
+  width: 'min(420px, 92vw)',
+  borderRadius: '12px',
+  border: '1px solid var(--border-default)',
+  background: 'linear-gradient(180deg, rgba(17,26,51,0.88) 0%, rgba(12,19,40,0.88) 100%)',
+  boxShadow: '0 20px 60px rgba(0,0,0,0.5)',
+  padding: '14px',
+  color: 'var(--text-primary)',
+};
+
+const optionStyle: CSSProperties = {
+  borderRadius: '8px',
+  border: '1px solid var(--border-subtle)',
+  background: 'rgba(255,255,255,0.03)',
+  padding: '10px 12px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  fontSize: '13px',
+};
+
+const ghostButtonStyle: CSSProperties = {
+  border: '1px solid var(--border-default)',
+  background: 'transparent',
+  color: 'var(--text-secondary)',
+  borderRadius: '7px',
+  padding: '6px 10px',
+  fontSize: '12px',
+  cursor: 'pointer',
+};
+

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,0 +1,2 @@
+export { GridSettingsPanel } from './components/GridSettingsPanel';
+

--- a/src/features/workspaces/components/WorkspaceContainer.tsx
+++ b/src/features/workspaces/components/WorkspaceContainer.tsx
@@ -20,8 +20,6 @@ import { Pane } from '../../panes/components/Pane';
 import { useAppStore, useActiveWorkspace } from '../../../stores';
 import type { Pane as PaneType, PaneLayout } from '../../../types';
 
-const GRID_COLS = 3;
-const GRID_ROWS = 3;
 const GAP = 8;
 const EMPTY_PANES: PaneType[] = [];
 
@@ -266,9 +264,11 @@ function layoutsOverlap(a: PaneLayout, b: PaneLayout): boolean {
 export function WorkspaceContainer() {
   const activeWorkspace = useActiveWorkspace();
   const activeWorkspaceId = useAppStore((state) => state.activeWorkspaceId);
+  const paneGridSize = useAppStore((state) => state.paneGridSize);
   const panes = activeWorkspace?.panes ?? EMPTY_PANES;
-  // Max 9 panes (3x3)
-  const visiblePanes = panes.slice(0, 9);
+  const GRID_COLS = paneGridSize;
+  const GRID_ROWS = paneGridSize;
+  const visiblePanes = panes.slice(0, GRID_COLS * GRID_ROWS);
   const [draggingPaneId, setDraggingPaneId] = useState<string | null>(null);
   const [dragOverCell, setDragOverCell] = useState<{ x: number; y: number } | null>(null);
 
@@ -304,7 +304,7 @@ export function WorkspaceContainer() {
       }
     }
     return empty;
-  }, [visiblePanes]);
+  }, [visiblePanes, GRID_COLS, GRID_ROWS]);
 
   const dragPreview = useMemo(() => {
     if (!draggingPaneId || !dragOverCell) return null;
@@ -320,7 +320,7 @@ export function WorkspaceContainer() {
       ...previewLayout,
       isValid,
     };
-  }, [dragOverCell, draggingPaneId, panes]);
+  }, [dragOverCell, draggingPaneId, panes, GRID_COLS, GRID_ROWS]);
 
   const handleResizeStart = useCallback((paneId: string, direction: 'left' | 'right' | 'top' | 'bottom' | 'corner') => {
     if (!activeWorkspaceId) return;
@@ -556,7 +556,7 @@ export function WorkspaceContainer() {
 
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('mouseup', handleMouseUp);
-  }, [activeWorkspaceId]);
+  }, [activeWorkspaceId, GRID_COLS, GRID_ROWS]);
 
   // Empty states
   if (!activeWorkspace || !activeWorkspaceId) {

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -30,6 +30,7 @@ describe('useKeyboardShortcuts', () => {
       workspaces: [createWorkspace()],
       activeWorkspaceId: 'ws-1',
       isWorkspaceSearchOpen: false,
+      isGridSettingsOpen: false,
     });
   });
 
@@ -112,5 +113,21 @@ describe('useKeyboardShortcuts', () => {
     await waitFor(() => {
       expect(useAppStore.getState().isRelayPanelOpen).toBe(true);
     });
+  });
+
+  it('opens grid settings on Cmd/Ctrl+Shift+G', () => {
+    render(<KeyboardShortcutHarness />);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'g',
+      metaKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(useAppStore.getState().isGridSettingsOpen).toBe(true);
   });
 });

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -13,6 +13,7 @@ export function useKeyboardShortcuts() {
   const zoomOut = useAppStore((state) => state.zoomOut);
   const resetZoom = useAppStore((state) => state.resetZoom);
   const openSnippetPicker = useAppStore((state) => state.openSnippetPicker);
+  const openGridSettings = useAppStore((state) => state.openGridSettings);
   const openWorkspaceSearch = useAppStore((state) => state.openWorkspaceSearch);
   const openRelayPanel = useAppStore((state) => state.openRelayPanel);
 
@@ -48,6 +49,13 @@ export function useKeyboardShortcuts() {
           const opened = await openRelayWindow();
           if (!opened) openRelayPanel();
         })();
+        return;
+      }
+
+      // Cmd/Ctrl+Shift+G: Open grid settings
+      if (isMod && e.shiftKey && e.key.toLowerCase() === 'g') {
+        e.preventDefault();
+        openGridSettings();
         return;
       }
 
@@ -164,6 +172,7 @@ export function useKeyboardShortcuts() {
     zoomOut,
     resetZoom,
     openSnippetPicker,
+    openGridSettings,
     openWorkspaceSearch,
     openRelayPanel,
   ]);

--- a/src/stores/slices/layoutSlice.ts
+++ b/src/stores/slices/layoutSlice.ts
@@ -8,6 +8,7 @@ export interface LayoutSlice {
   isNewPaneModalOpen: boolean;
   isPaneSwitcherOpen: boolean;
   isSnippetPickerOpen: boolean;
+  isGridSettingsOpen: boolean;
   isWorkspaceSearchOpen: boolean;
   isRelayPanelOpen: boolean;
   editingPaneId: string | null;
@@ -25,6 +26,8 @@ export interface LayoutSlice {
   closePaneEditor: () => void;
   openSnippetPicker: () => void;
   closeSnippetPicker: () => void;
+  openGridSettings: () => void;
+  closeGridSettings: () => void;
   openWorkspaceSearch: () => void;
   closeWorkspaceSearch: () => void;
   openRelayPanel: () => void;
@@ -42,6 +45,7 @@ export const createLayoutSlice: StateCreator<
   isNewPaneModalOpen: false,
   isPaneSwitcherOpen: false,
   isSnippetPickerOpen: false,
+  isGridSettingsOpen: false,
   isWorkspaceSearchOpen: false,
   isRelayPanelOpen: false,
   editingPaneId: null,
@@ -92,6 +96,14 @@ export const createLayoutSlice: StateCreator<
 
   closeSnippetPicker: () => {
     set({ isSnippetPickerOpen: false });
+  },
+
+  openGridSettings: () => {
+    set({ isGridSettingsOpen: true });
+  },
+
+  closeGridSettings: () => {
+    set({ isGridSettingsOpen: false });
   },
 
   openWorkspaceSearch: () => {

--- a/src/stores/slices/panesSlice.ts
+++ b/src/stores/slices/panesSlice.ts
@@ -122,8 +122,8 @@ export const createPanesSlice: StateCreator<
     const existingPanes = workspace?.panes || [];
 
     // Build occupancy grid to find empty cell
-    const GRID_COLS = 3;
-    const GRID_ROWS = 3;
+    const GRID_COLS = get().paneGridSize;
+    const GRID_ROWS = get().paneGridSize;
     const grid = new Set<string>();
 
     for (const p of existingPanes) {
@@ -220,8 +220,8 @@ export const createPanesSlice: StateCreator<
     const existingPanes = workspace?.panes || [];
 
     // Build occupancy grid to find empty cell
-    const GRID_COLS = 3;
-    const GRID_ROWS = 3;
+    const GRID_COLS = get().paneGridSize;
+    const GRID_ROWS = get().paneGridSize;
     const grid = new Set<string>();
 
     for (const p of existingPanes) {
@@ -294,8 +294,8 @@ export const createPanesSlice: StateCreator<
   },
 
   updatePaneLayouts: (workspaceId, layouts) => {
-    const GRID_COLS = 3;
-    const GRID_ROWS = 3;
+    const GRID_COLS = get().paneGridSize;
+    const GRID_ROWS = get().paneGridSize;
 
     // Validate and clamp layouts to grid bounds
     const validatedLayouts = layouts.map((l) => ({

--- a/src/stores/slices/zustandSlices.test.ts
+++ b/src/stores/slices/zustandSlices.test.ts
@@ -155,6 +155,21 @@ describe('panesSlice', () => {
     expect(workspace.dirty).toBe(true);
   });
 
+  it('allows up to 16 panes when pane grid size is 4x4', () => {
+    useAppStore.getState().setPaneGridSize(4);
+
+    const ids: string[] = [];
+    for (let i = 0; i < 16; i += 1) {
+      const id = useAppStore.getState().createPane('ws-1', { title: `Pane ${i + 1}` });
+      ids.push(id);
+    }
+    const overflow = useAppStore.getState().createPane('ws-1', { title: 'Overflow' });
+
+    expect(ids.every((id) => id.length > 0)).toBe(true);
+    expect(useAppStore.getState().workspaces[0].panes).toHaveLength(16);
+    expect(overflow).toBe('');
+  });
+
   it('updates pane title and keeps change in store', () => {
     const paneId = useAppStore.getState().createPane('ws-1', { title: 'Pane 1' });
 


### PR DESCRIPTION
## Summary
- add configurable pane grid size: `3x3` / `4x4`
- add Grid Settings panel and shortcut `Cmd/Ctrl + Shift + G`
- apply dynamic grid size to pane create/duplicate/layout bounds
- clamp pane layouts when switching from `4x4` back to `3x3`
- update README and README.ja for grid settings and shortcut

## Regression checks
- Relay open shortcut (`Cmd/Ctrl + Shift + R`) still works
- Relay single-pane self-send behavior remains intact
- existing resize/drag behavior remains stable after grid-size switch

## Verification
- npm run check:full
  - lint
  - test (45 passed)
  - build
  - cargo check

## Notes
- Vite chunk-size warning remains as known non-blocking warning
