### PR TITLE
fix: start PTY shell as login shell for PATH

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -221,8 +221,8 @@ impl PtyManager {
         if cfg!(target_os = "windows") {
             vec![]
         } else {
-            // No args - let shell start normally
-            vec![]
+            // Start as login shell so PATH from shell profile (e.g. ~/.zprofile) is loaded.
+            vec!["-l".to_string()]
         }
     }
 }


### PR DESCRIPTION
## Summary
  - start PTY shell as a login shell on non-Windows platforms
  - ensure shell startup files (e.g. ~/.zprofile) are loaded in app terminal tabs
  - fix PATH mismatch where commands like aws were not found in tab terminal

  ## Verification
  - cargo check --manifest-path src-tauri/Cargo.toml
  - pre-commit hook: npm run check:fast
  - pre-push hook: npm run check:full