### PR TITLE
feat: add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,11 @@ jobs:
 
   tauri:
     name: Tauri (cargo check)
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,12 @@ concurrency:
 
 jobs:
   tauri-release:
-    name: Tauri Release (macOS)
-    runs-on: macos-latest
+    name: Tauri Release (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
 
@@ -41,7 +45,8 @@ jobs:
       - name: Build Tauri app
         run: npm run tauri build
 
-      - name: Upload release artifacts
+      - name: Upload release artifacts (macOS)
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: tauri-bundles-macos
@@ -49,8 +54,16 @@ jobs:
             src-tauri/target/release/bundle/**
             !src-tauri/target/release/bundle/**/*.dmg
 
+      - name: Upload release artifacts (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-bundles-windows
+          path: src-tauri/target/release/bundle/**
+
       - name: Generate SHA256 checksums
         if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
         run: |
           set -euo pipefail
           cd src-tauri/target/release/bundle
@@ -58,8 +71,10 @@ jobs:
             -name "*.app.tar.gz" -o \
             -name "*.app.tar.gz.sig" -o \
             -name "*.tar.gz" -o \
+            -name "*.msi" -o \
+            -name "*.exe" -o \
             -name "*.sig" \
-          \) -print0 | sort -z | xargs -0 shasum -a 256 > SHA256SUMS.txt
+          \) -print0 | sort -z | xargs -0 shasum -a 256 > "SHA256SUMS-${RUNNER_OS}.txt"
 
       - name: Publish GitHub Release assets
         if: startsWith(github.ref, 'refs/tags/')
@@ -70,5 +85,7 @@ jobs:
             src-tauri/target/release/bundle/**/*.app.tar.gz
             src-tauri/target/release/bundle/**/*.app.tar.gz.sig
             src-tauri/target/release/bundle/**/*.tar.gz
+            src-tauri/target/release/bundle/**/*.msi
+            src-tauri/target/release/bundle/**/*.exe
             src-tauri/target/release/bundle/**/*.sig
-            src-tauri/target/release/bundle/SHA256SUMS.txt
+            src-tauri/target/release/bundle/SHA256SUMS-*.txt

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ fn append_lifecycle_log(message: &str) {
     if let Ok(mut file) = OpenOptions::new()
         .create(true)
         .append(true)
-        .open("/tmp/tabbed-terminal-lifecycle.log")
+        .open(std::env::temp_dir().join("tabbed-terminal-lifecycle.log"))
     {
         let _ = file.write_all(line.as_bytes());
     }
@@ -42,7 +42,7 @@ fn install_panic_hook() {
         if let Ok(mut file) = OpenOptions::new()
             .create(true)
             .append(true)
-            .open("/tmp/tabbed-terminal-panic.log")
+            .open(std::env::temp_dir().join("tabbed-terminal-panic.log"))
         {
             let _ = file.write_all(body.as_bytes());
         }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -48,14 +48,17 @@ impl PtyManager {
         for arg in Self::get_shell_args() {
             cmd.arg(arg);
         }
-        cmd.env("TERM", "xterm-256color");
         // Disable zsh session management (causes early exit)
         cmd.env("SHELL_SESSIONS_DISABLE", "1");
-        // Explicit UTF-8 locale to reduce encoding mismatches.
-        cmd.env("LANG", "en_US.UTF-8");
-        cmd.env("LC_ALL", "en_US.UTF-8");
-        // Set HOME directory
-        if let Ok(home) = std::env::var("HOME") {
+        // These are Unix shell/terminal conventions; PowerShell/ConPTY ignore them.
+        if !cfg!(target_os = "windows") {
+            cmd.env("TERM", "xterm-256color");
+            // Explicit UTF-8 locale to reduce encoding mismatches.
+            cmd.env("LANG", "en_US.UTF-8");
+            cmd.env("LC_ALL", "en_US.UTF-8");
+        }
+        // Set working directory to the user's home (HOME on Unix, USERPROFILE on Windows).
+        if let Some(home) = Self::home_dir() {
             cmd.cwd(&home);
             cmd.env("HOME", &home);
         }
@@ -63,8 +66,8 @@ impl PtyManager {
         if let Ok(path) = std::env::var("PATH") {
             cmd.env("PATH", path);
         }
-        // Set user
-        if let Ok(user) = std::env::var("USER") {
+        // Set user (USER on Unix, USERNAME on Windows)
+        if let Ok(user) = std::env::var("USER").or_else(|_| std::env::var("USERNAME")) {
             cmd.env("USER", user);
         }
 
@@ -207,6 +210,16 @@ impl PtyManager {
             .map_err(|_| "PTY manager lock poisoned".to_string())?;
         instances.remove(id);
         Ok(())
+    }
+
+    fn home_dir() -> Option<String> {
+        if cfg!(target_os = "windows") {
+            std::env::var("USERPROFILE")
+                .or_else(|_| std::env::var("HOME"))
+                .ok()
+        } else {
+            std::env::var("HOME").ok()
+        }
     }
 
     fn get_shell() -> String {

--- a/src/features/panes/components/Terminal.tsx
+++ b/src/features/panes/components/Terminal.tsx
@@ -170,7 +170,8 @@ export function Terminal({ paneId, isFocused, onFocus }: TerminalProps) {
     const terminal = new XTerm({
       cursorBlink: true,
       fontSize: currentFontSize,
-      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      fontFamily:
+        'Menlo, Monaco, "Cascadia Code", "Cascadia Mono", Consolas, "DejaVu Sans Mono", "Courier New", monospace',
       scrollback: 10000,
       scrollOnUserInput: true,
       theme: {


### PR DESCRIPTION
## 概要

Tabbed Terminal を Windows でも動作できるように対応しました。コアの PTY は `portable-pty` が Windows の ConPTY を自動選択するため、主な修正は環境変数・パス・フォント・CI です。

## 変更内容

### `src-tauri/src/pty.rs`
- ホームディレクトリ判定を追加（Windows: `USERPROFILE`→`HOME`、Unix: `HOME`）。Windows でもユーザーのホームでシェルが起動するように
- `USER` が無い Windows では `USERNAME` にフォールバック
- `TERM` / `LANG` / `LC_ALL`（Unix 専用の規約）は非 Windows のみ設定

### `src-tauri/src/lib.rs`
- デバッグログの `/tmp/...` ハードコードを `std::env::temp_dir()` ベースに変更

### `src/features/panes/components/Terminal.tsx`
- フォントスタックに Windows/Linux 向け（Cascadia Code/Mono, Consolas, DejaVu Sans Mono）を追加

### CI / Release
- `ci.yml`: `cargo check` を macOS + Windows の matrix に
- `release.yml`: リリースを macOS + Windows の matrix 化、`.msi` / `.exe` を成果物・リリースアセットに追加、チェックサム生成を `shell: bash` でクロスプラットフォーム化

## 検証

- `cargo check` ✅（Windows 分岐含めコンパイル通過）
- `npm run lint` ✅
- `npm run test` ✅ 45/45 passed

## 補足

- 実機での起動・bundle 生成確認は Windows 環境（または本 PR の CI Windows ジョブ）で行う必要があります