### PR TITLE
fix: retain background tab terminal output across tab switches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,14 @@ import { WorkspaceSearch } from './features/search';
 import { SnippetPicker } from './features/snippets';
 import { RelayPanel, useRelayStateBridge } from './features/relay';
 import { WorkspaceContainer } from './features/workspaces';
+import { useTerminalOutputCollector } from './features/panes/terminalOutputCollector';
 import { useInitialize, useKeyboardShortcuts } from './hooks';
 
 function App() {
   useInitialize();
   useKeyboardShortcuts();
   useRelayStateBridge();
+  useTerminalOutputCollector();
   const isTauriRuntime =
     typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 

--- a/src/features/panes/components/Terminal.tsx
+++ b/src/features/panes/components/Terminal.tsx
@@ -2,8 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { invoke } from '@tauri-apps/api/core';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { useAppStore } from '../../../stores';
+import {
+  ensurePtyListener,
+  registerLiveTerminal,
+  unregisterLiveTerminal,
+} from '../terminalOutputCollector';
 import '@xterm/xterm/css/xterm.css';
 
 interface TerminalProps {
@@ -29,7 +33,6 @@ export function Terminal({ paneId, isFocused, onFocus }: TerminalProps) {
   const fitAddonRef = useRef<FitAddon | null>(null);
   const ptySpawnedRef = useRef(false);
   const terminalFontSize = useAppStore((state) => state.terminalFontSize);
-  const appendTerminalOutput = useAppStore((state) => state.appendTerminalOutput);
 
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -163,8 +166,6 @@ export function Terminal({ paneId, isFocused, onFocus }: TerminalProps) {
     if (!containerRef.current || terminalRef.current) return;
 
     let aborted = false;
-    let unlistenOutput: UnlistenFn | null = null;
-    let unlistenExit: UnlistenFn | null = null;
 
     const currentFontSize = useAppStore.getState().terminalFontSize;
     const terminal = new XTerm({
@@ -191,6 +192,9 @@ export function Terminal({ paneId, isFocused, onFocus }: TerminalProps) {
       terminal.write(savedHistory);
       terminal.scrollToBottom();
     }
+    // Attach synchronously, immediately after replaying the stored history, so
+    // no chunk arrives between the snapshot read above and live rendering.
+    registerLiveTerminal(paneId, terminal);
 
     terminalRef.current = terminal;
     fitAddonRef.current = fitAddon;
@@ -209,28 +213,11 @@ export function Terminal({ paneId, isFocused, onFocus }: TerminalProps) {
       if (ptySpawnedRef.current || aborted) return;
 
       try {
-        unlistenOutput = await listen<string>(`pty-output-${paneId}`, (event) => {
-          if (!aborted) {
-            terminal.write(event.payload);
-            terminal.scrollToBottom();
-            appendTerminalOutput(paneId, event.payload);
-          }
-        });
+        // Ensure the persistent collector listener is ready before spawning so
+        // the first bytes of shell output are captured even on a fresh pane.
+        await ensurePtyListener(paneId);
 
-        if (aborted) {
-          unlistenOutput?.();
-          return;
-        }
-
-        unlistenExit = await listen(`pty-exit-${paneId}`, () => {
-          if (!aborted) terminal.writeln('\r\n\x1b[1;31m[Process exited]\x1b[0m');
-        });
-
-        if (aborted) {
-          unlistenOutput?.();
-          unlistenExit?.();
-          return;
-        }
+        if (aborted) return;
 
         await invoke('pty_spawn', { id: paneId });
 
@@ -270,8 +257,7 @@ export function Terminal({ paneId, isFocused, onFocus }: TerminalProps) {
     return () => {
       aborted = true;
       resizeObserver.disconnect();
-      unlistenOutput?.();
-      unlistenExit?.();
+      unregisterLiveTerminal(paneId, terminal);
       const paneStillExists = useAppStore
         .getState()
         .workspaces.some((workspace) => workspace.panes.some((pane) => pane.id === paneId));
@@ -282,7 +268,7 @@ export function Terminal({ paneId, isFocused, onFocus }: TerminalProps) {
       terminal.dispose();
       terminalRef.current = null;
     };
-  }, [appendTerminalOutput, paneId, syncTerminalSize]);
+  }, [paneId, syncTerminalSize]);
 
   useEffect(() => {
     if (isFocused && terminalRef.current) {

--- a/src/features/panes/terminalOutputCollector.test.ts
+++ b/src/features/panes/terminalOutputCollector.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { handlers } = vi.hoisted(() => ({
+  handlers: new Map<string, (event: { payload: unknown }) => void>(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (event: string, cb: (event: { payload: unknown }) => void) => {
+    handlers.set(event, cb);
+    return () => handlers.delete(event);
+  }),
+}));
+
+import {
+  ensurePtyListener,
+  registerLiveTerminal,
+  removePtyListener,
+  unregisterLiveTerminal,
+} from './terminalOutputCollector';
+import { useAppStore } from '../../stores';
+
+function emit(paneId: string, payload: string) {
+  handlers.get(`pty-output-${paneId}`)?.({ payload });
+}
+
+describe('terminalOutputCollector', () => {
+  beforeEach(() => {
+    handlers.clear();
+  });
+
+  afterEach(() => {
+    removePtyListener('pane-bg');
+    removePtyListener('pane-live');
+    useAppStore.getState().clearTerminalHistory('pane-bg');
+    useAppStore.getState().clearTerminalHistory('pane-live');
+  });
+
+  it('persists output to the store even when no live terminal is attached', async () => {
+    await ensurePtyListener('pane-bg');
+
+    // Simulate the backend emitting while the pane's tab is backgrounded
+    // (no Terminal component mounted, so no live terminal registered).
+    emit('pane-bg', 'background output');
+
+    expect(useAppStore.getState().terminalRawHistoryByPane['pane-bg']).toBe('background output');
+  });
+
+  it('forwards output to a registered live terminal and stops after unregister', async () => {
+    await ensurePtyListener('pane-live');
+    const live = { write: vi.fn(), scrollToBottom: vi.fn() };
+    registerLiveTerminal('pane-live', live);
+
+    emit('pane-live', 'visible chunk');
+    expect(live.write).toHaveBeenCalledWith('visible chunk');
+    expect(useAppStore.getState().terminalRawHistoryByPane['pane-live']).toBe('visible chunk');
+
+    unregisterLiveTerminal('pane-live', live);
+    emit('pane-live', ' more');
+
+    // Live terminal no longer receives chunks, but the store keeps accumulating.
+    expect(live.write).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().terminalRawHistoryByPane['pane-live']).toBe('visible chunk more');
+  });
+
+  it('only registers a listener once per pane', async () => {
+    const { listen } = await import('@tauri-apps/api/event');
+    const callsBefore = (listen as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    await ensurePtyListener('pane-bg');
+    await ensurePtyListener('pane-bg');
+
+    // Two listen() calls (pty-output + pty-exit) for the first ensure, none for the second.
+    expect((listen as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsBefore + 2);
+  });
+});

--- a/src/features/panes/terminalOutputCollector.ts
+++ b/src/features/panes/terminalOutputCollector.ts
@@ -1,0 +1,131 @@
+import { useEffect } from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { useAppStore } from '../../stores';
+
+/**
+ * Always-on PTY output collector.
+ *
+ * Previously each `Terminal` component owned the only `pty-output-<id>`
+ * listener. Because inactive tabs unmount their `Terminal`, the listener (and
+ * the store append it performed) was torn down whenever the user switched
+ * tabs, so any output a backgrounded shell produced was emitted by the backend
+ * with nobody listening and silently lost. Switching back then replayed an
+ * incomplete history, corrupting the rendered screen.
+ *
+ * This module keeps one listener alive per pane for the pane's whole lifetime,
+ * independent of which tab is mounted. Incoming chunks are always persisted to
+ * the store, and additionally forwarded to a live xterm instance when one is
+ * registered (i.e. when that pane's tab is currently visible).
+ */
+
+interface LiveTerminal {
+  write: (data: string) => void;
+  scrollToBottom: () => void;
+}
+
+const EXIT_MARKER = '\r\n\x1b[1;31m[Process exited]\x1b[0m\r\n';
+
+/** Pending/active listener handles, keyed by paneId. Presence = listener owned. */
+const listeners = new Map<string, Promise<UnlistenFn[]>>();
+/** Live xterm instances for currently-mounted panes, keyed by paneId. */
+const liveTerminals = new Map<string, LiveTerminal>();
+
+function pushChunk(paneId: string, chunk: string): void {
+  if (!chunk) return;
+  // Persist first so a remount always replays the complete stream.
+  useAppStore.getState().appendTerminalOutput(paneId, chunk);
+  // Forward to the visible terminal, if any, for live rendering.
+  const live = liveTerminals.get(paneId);
+  if (live) {
+    live.write(chunk);
+    live.scrollToBottom();
+  }
+}
+
+/**
+ * Ensure a persistent listener exists for `paneId`. Idempotent and safe to call
+ * concurrently. Callers should await this before spawning the PTY so the very
+ * first bytes of shell output are captured.
+ */
+export async function ensurePtyListener(paneId: string): Promise<void> {
+  const existing = listeners.get(paneId);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const handlesPromise = Promise.all([
+    listen<string>(`pty-output-${paneId}`, (event) => {
+      pushChunk(paneId, event.payload);
+    }),
+    listen(`pty-exit-${paneId}`, () => {
+      pushChunk(paneId, EXIT_MARKER);
+    }),
+  ]);
+
+  listeners.set(paneId, handlesPromise);
+  await handlesPromise;
+}
+
+/** Tear down the listener for a pane that no longer exists. */
+export function removePtyListener(paneId: string): void {
+  const handlesPromise = listeners.get(paneId);
+  if (handlesPromise) {
+    listeners.delete(paneId);
+    handlesPromise
+      .then((handles) => handles.forEach((unlisten) => unlisten()))
+      .catch(() => {});
+  }
+  liveTerminals.delete(paneId);
+}
+
+/**
+ * Attach a visible xterm so subsequent chunks render live. Must be called
+ * synchronously right after replaying the stored history, so no chunk slips
+ * through between the snapshot read and attachment.
+ */
+export function registerLiveTerminal(paneId: string, terminal: LiveTerminal): void {
+  liveTerminals.set(paneId, terminal);
+}
+
+export function unregisterLiveTerminal(paneId: string, terminal: LiveTerminal): void {
+  if (liveTerminals.get(paneId) === terminal) {
+    liveTerminals.delete(paneId);
+  }
+}
+
+function collectPaneIds(workspaces: ReturnType<typeof useAppStore.getState>['workspaces']): Set<string> {
+  const ids = new Set<string>();
+  workspaces.forEach((workspace) => workspace.panes.forEach((pane) => ids.add(pane.id)));
+  return ids;
+}
+
+/**
+ * Mount once (at the app root) to keep listeners in sync with the set of panes
+ * that exist across all workspaces, creating listeners for new panes and
+ * removing them when a pane is destroyed.
+ */
+export function useTerminalOutputCollector(): void {
+  useEffect(() => {
+    // `workspaces` keeps a stable reference while only terminal output changes,
+    // so this guard makes the high-frequency output path essentially free.
+    let lastWorkspaces: ReturnType<typeof useAppStore.getState>['workspaces'] | null = null;
+
+    const sync = (state: ReturnType<typeof useAppStore.getState>) => {
+      if (state.workspaces === lastWorkspaces) return;
+      lastWorkspaces = state.workspaces;
+
+      const ids = collectPaneIds(state.workspaces);
+      ids.forEach((id) => {
+        void ensurePtyListener(id);
+      });
+      for (const id of [...listeners.keys()]) {
+        if (!ids.has(id)) removePtyListener(id);
+      }
+    };
+
+    sync(useAppStore.getState());
+    const unsubscribe = useAppStore.subscribe(sync);
+    return () => unsubscribe();
+  }, []);
+}


### PR DESCRIPTION
## 概要

タブを切り替えると、バックグラウンドになったタブのターミナル表示が崩れる/出力が抜ける問題を修正します。

## 原因

非アクティブなタブは `WorkspaceContainer` がアクティブ workspace の pane のみを描画するため、**Terminal が完全にアンマウント**されます。`pty-output-<id>` を購読しストアへ履歴を保存していたのは `Terminal` 内の唯一のリスナーで、アンマウント時に解除されます。一方 Rust 側の reader スレッドは PTY を読み続け `emit` し続けますが、**聞いている人が居ないため出力が丸ごと欠落**します（Tauri の emit はバッファしない）。

タブに戻ると新しい xterm に `terminalRawHistoryByPane` を replay しますが、その履歴にはバックグラウンド中の出力が抜けているため、特に欠落区間に ANSI 制御列（カーソル位置・色・画面クリア）が含まれると vim/htop/top などの TUI が崩れます。

## 修正

常時稼働の **PTY 出力コレクタ** を導入しました。

- `src/features/panes/terminalOutputCollector.ts`（新規）
  - pane ごとに `pty-output` / `pty-exit` をアプリ起動中ずっと購読（タブ非アクティブでも生存）
  - 受信チャンクは必ずストアへ保存し、前面に登録済みのライブ端末があれば即 `write`
  - `useTerminalOutputCollector` フックが pane 生成/破棄に合わせてリスナーを増減。`workspaces` の参照同一性でガードし高頻度の出力パスはほぼゼロコスト
- `src/features/panes/components/Terminal.tsx`
  - 自前の listener とストア保存を撤去
  - マウント時に履歴 replay → 同期的にライブ端末を登録（スナップショットと登録の間にギャップが生じない）
  - spawn 前に `ensurePtyListener` を待ち、初回プロンプトの取りこぼしも防止
- `src/App.tsx`
  - コレクタフックを常駐化

## 副次的な改善

バックグラウンドのタブの活動も検知できるようになり、未読バッジが正しく付くようになります。

## テスト

- `src/features/panes/terminalOutputCollector.test.ts`（新規）: ライブ端末未登録でもストアへ保存される / 登録時は転送・解除後は停止 / リスナーは pane ごとに1回だけ
- `npm run lint` ✅ / `tsc --noEmit` ✅ / `npm run test` ✅ 48 passed

## 既知の別件（本PR対象外）

`pty_kill` は Terminal からのみ呼ばれるため、バックグラウンドのタブにある pane を閉じると PTY が残るリークが既存であります。必要なら別途対応します。