### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## v0.5.1 - 2026-06-24
+
+### Maintenance
+- Automated patch version bump to `v0.5.1`.
+- Source merged PR: (not provided).
 ## v0.5.0 - 2026-02-23
 
 ### Maintenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabbed-terminal",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabbed-terminal",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabbed-terminal",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "engines": {
     "node": ">=22.12 <23 || >=24 <25",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "tabbed-terminal"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "log",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabbed-terminal"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Tauri App"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Tabbed Terminal",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.tabbed-terminal.ide",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump version 0.5.0 → 0.5.1 across package.json / package-lock / tauri.conf.json / Cargo.toml / Cargo.lock
- append CHANGELOG entry

## Why
Cut a `v0.5.1` release so GitHub Actions publishes the **Windows installers (.msi/.exe)** to the Releases page. Windows build was verified green via manual run #6 (artifacts produced), but `workflow_dispatch` does not attach to a release — a `v*` tag is required.