### PR TITLE
ci: fix release asset publishing (Windows checksums, macOS dmg)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tauri-bundles-macos
-          path: |
-            src-tauri/target/release/bundle/**
-            !src-tauri/target/release/bundle/**/*.dmg
+          path: src-tauri/target/release/bundle/**
 
       - name: Upload release artifacts (Windows)
         if: runner.os == 'Windows'
@@ -67,14 +65,31 @@ jobs:
         run: |
           set -euo pipefail
           cd src-tauri/target/release/bundle
-          find . -type f \( \
-            -name "*.app.tar.gz" -o \
-            -name "*.app.tar.gz.sig" -o \
-            -name "*.tar.gz" -o \
-            -name "*.msi" -o \
-            -name "*.exe" -o \
-            -name "*.sig" \
-          \) -print0 | sort -z | xargs -0 shasum -a 256 > "SHA256SUMS-${RUNNER_OS}.txt"
+          # Release artifacts to checksum (filenames may contain spaces).
+          find_artifacts() {
+            find . -type f \( \
+              -name "*.app.tar.gz" -o \
+              -name "*.app.tar.gz.sig" -o \
+              -name "*.tar.gz" -o \
+              -name "*.msi" -o \
+              -name "*.exe" -o \
+              -name "*.dmg" -o \
+              -name "*.sig" \
+            \) "$@"
+          }
+          # Guard against an empty result so we never publish an empty
+          # SHA256SUMS file (GitHub rejects 0-byte assets).
+          if [ -z "$(find_artifacts)" ]; then
+            echo "No bundle artifacts to checksum on ${RUNNER_OS}; skipping."
+            exit 0
+          fi
+          # shasum is absent on Windows runners; prefer sha256sum when available.
+          if command -v sha256sum >/dev/null 2>&1; then
+            hash_cmd="sha256sum"
+          else
+            hash_cmd="shasum -a 256"
+          fi
+          find_artifacts -print0 | sort -z | xargs -0 $hash_cmd > "SHA256SUMS-${RUNNER_OS}.txt"
 
       - name: Publish GitHub Release assets
         if: startsWith(github.ref, 'refs/tags/')
@@ -87,5 +102,6 @@ jobs:
             src-tauri/target/release/bundle/**/*.tar.gz
             src-tauri/target/release/bundle/**/*.msi
             src-tauri/target/release/bundle/**/*.exe
+            src-tauri/target/release/bundle/**/*.dmg
             src-tauri/target/release/bundle/**/*.sig
             src-tauri/target/release/bundle/SHA256SUMS-*.txt


### PR DESCRIPTION
## Summary
Fix the tag-triggered release so installers actually publish to the Releases page. These steps run only on `v*` tags and had never been exercised, so two latent bugs failed the v0.5.1 attempt:

- **Windows `Generate SHA256 checksums` → exit 127**: `shasum` is not present on Windows runners. Now prefers `sha256sum` (available in Git Bash), falling back to `shasum -a 256` on macOS.
- **macOS `Publish GitHub Release assets` → `size must be >= 1`**: the checksum step produced a 0-byte `SHA256SUMS-macOS.txt` because no artifacts matched (dmg was excluded). Now guards against an empty result and skips writing the file.

Also re-enables **macOS dmg** distribution (was dropped in a prior commit, leaving macOS releases with no asset):
- include `*.dmg` in the checksum set and the publish `files` list
- stop excluding the dmg from the macOS verification artifact

## Verification
Checksum bash logic validated locally against real Windows `.msi`/`.exe` artifacts and a synthetic macOS dmg (spaces in filenames handled; empty case skips cleanly).